### PR TITLE
Type Proxies

### DIFF
--- a/lib/src/main/java/com/wjduquette/joe/Interpreter.java
+++ b/lib/src/main/java/com/wjduquette/joe/Interpreter.java
@@ -273,7 +273,7 @@ public class Interpreter {
                 } else {
                     var proxy = joe.lookupProxy(object);
                     if (proxy != null) {
-                        yield proxy.findMethod(object, expr.name().lexeme());
+                        yield proxy.bind(object, expr.name().lexeme());
                     }
                 }
 

--- a/lib/src/main/java/com/wjduquette/joe/Interpreter.java
+++ b/lib/src/main/java/com/wjduquette/joe/Interpreter.java
@@ -268,8 +268,13 @@ public class Interpreter {
             }
             case Expr.Get expr -> {
                 Object object = evaluate(expr.object());
-                if (object instanceof JoeInstance) {
-                    yield ((JoeInstance) object).get(expr.name());
+                if (object instanceof JoeInstance instance) {
+                    yield instance.get(expr.name());
+                } else {
+                    var proxy = joe.lookupProxy(object);
+                    if (proxy != null) {
+                        yield proxy.findMethod(object, expr.name().lexeme());
+                    }
                 }
 
                 throw joe.expected("object", object);

--- a/lib/src/main/java/com/wjduquette/joe/Interpreter.java
+++ b/lib/src/main/java/com/wjduquette/joe/Interpreter.java
@@ -19,7 +19,7 @@ public class Interpreter {
 
     public Interpreter(Joe joe) {
         this.joe = joe;
-        this.globals = joe.getGlobalEnvironment();
+        this.globals = joe.getGlobals();
         this.environment = globals;
     }
 

--- a/lib/src/main/java/com/wjduquette/joe/Joe.java
+++ b/lib/src/main/java/com/wjduquette/joe/Joe.java
@@ -249,7 +249,12 @@ public class Joe {
         return switch (value) {
             case null -> null;
             case JoeFunction function -> toInitialCap(function.kind());
-            default -> value.getClass().getSimpleName();
+            default -> {
+                var proxy = lookupProxy(value);
+                yield proxy != null
+                    ? proxy.getTypeName()
+                    : value.getClass().getSimpleName();
+            }
         };
     }
 

--- a/lib/src/main/java/com/wjduquette/joe/Joe.java
+++ b/lib/src/main/java/com/wjduquette/joe/Joe.java
@@ -149,10 +149,16 @@ public class Joe {
     }
 
     /**
-     * Looks for a proxy for this object's class, or any of its
-     * superclasses.
-     * @param object
-     * @return
+     * Looks for a proxy for this object's class or its superclasses.
+     *
+     * <p><b>Note:</b> The construction of the proxyTable depends on
+     * the proxied types returned by each TypeProxy; and the proxiedTypes
+     * are constrained to be compatible with the TypeProxy's value type.
+     * Thus, if this method returns a proxy, it will *always* be
+     * compatible with the given object.
+     * </p>
+     * @param object The object for which we are looking up a proxy.
+     * @return The proxy, or null
      */
     TypeProxy<?> lookupProxy(Object object) {
         var cls = object.getClass();

--- a/lib/src/main/java/com/wjduquette/joe/Joe.java
+++ b/lib/src/main/java/com/wjduquette/joe/Joe.java
@@ -161,7 +161,6 @@ public class Joe {
      * @return The proxy, or null
      */
     TypeProxy<?> lookupProxy(Object object) {
-        var cls = object.getClass();
         return lookupProxyByClass(object.getClass());
     }
 
@@ -403,11 +402,11 @@ public class Joe {
     @SuppressWarnings("unchecked")
     public <T> T toType(Class<T> cls, Object arg) {
         if (arg != null && cls.isAssignableFrom(arg.getClass())) {
-            return (T)arg;
+            return (T) arg;
         } else {
             var proxy = lookupProxyByClass(cls);
             var typeName = proxy != null
-                ? proxy.getTypeName() : arg.getClass().getSimpleName();
+                ? proxy.getTypeName() : cls.getSimpleName();
             throw expected(typeName, arg);
         }
     }

--- a/lib/src/main/java/com/wjduquette/joe/Joe.java
+++ b/lib/src/main/java/com/wjduquette/joe/Joe.java
@@ -11,7 +11,7 @@ public class Joe {
     //-------------------------------------------------------------------------
     // Instance Variables
 
-    private final GlobalEnvironment globalEnvironment;
+    private final GlobalEnvironment globals;
     private final Interpreter interpreter;
     private final Codifier codifier;
     private final Map<Class<?>, TypeProxy<?>> proxyTable = new HashMap<>();
@@ -20,7 +20,7 @@ public class Joe {
     // Constructor
 
     public Joe() {
-        globalEnvironment = new GlobalEnvironment();
+        globals = new GlobalEnvironment();
         interpreter = new Interpreter(this);
         codifier = new Codifier(this);
 
@@ -30,8 +30,8 @@ public class Joe {
     //-------------------------------------------------------------------------
     // Configuration and Embedding
 
-    public GlobalEnvironment getGlobalEnvironment() {
-        return globalEnvironment;
+    public GlobalEnvironment getGlobals() {
+        return globals;
     }
 
     /**
@@ -39,7 +39,7 @@ public class Joe {
      * @param function The function
      */
     public void installGlobalFunction(NativeFunction function) {
-        globalEnvironment.define(function.name(), function);
+        globals.define(function.name(), function);
     }
 
     public void installType(TypeProxy<?> typeProxy) {
@@ -48,8 +48,8 @@ public class Joe {
             proxyTable.put(cls, typeProxy);
         }
 
-        // TODO: Install global function, etc., when we have them, or
-        // have the proxy do it.
+        // NEXT, install the type into the environment.
+        globals.define(typeProxy.getTypeName(), typeProxy);
     }
 
     /**

--- a/lib/src/main/java/com/wjduquette/joe/JoeValueCallable.java
+++ b/lib/src/main/java/com/wjduquette/joe/JoeValueCallable.java
@@ -1,0 +1,11 @@
+package com.wjduquette.joe;
+
+import java.util.List;
+
+/**
+ * An interface for a native method, defined as part of a `TypeProxy`.
+ * @param <V> The value type
+ */
+public interface JoeValueCallable<V> {
+    Object call(V value, Joe joe, List<Object> args);
+}

--- a/lib/src/main/java/com/wjduquette/joe/Library.java
+++ b/lib/src/main/java/com/wjduquette/joe/Library.java
@@ -8,6 +8,7 @@ public class Library {
     // Instance Variables
 
     private final List<NativeFunction> globalFunctions = new ArrayList<>();
+    private final List<TypeProxy<?>> types = new ArrayList<>();
 
     //-------------------------------------------------------------------------
     // Constructor
@@ -23,6 +24,10 @@ public class Library {
         globalFunctions.add(new NativeFunction(name, callable));
     }
 
+    protected final void type(TypeProxy<?> typeProxy) {
+        types.add(typeProxy);
+    }
+
     /**
      * Installs the library's native functions and types into the
      * engine.
@@ -30,5 +35,6 @@ public class Library {
      */
     public final void install(Joe joe) {
         globalFunctions.forEach(joe::installGlobalFunction);
+        types.forEach(joe::installType);
     }
 }

--- a/lib/src/main/java/com/wjduquette/joe/Pair.java
+++ b/lib/src/main/java/com/wjduquette/joe/Pair.java
@@ -1,0 +1,8 @@
+package com.wjduquette.joe;
+
+/**
+ * A pair of objects; used to return two things from a Joe function.
+ * @param left The first value
+ * @param right The second value
+ */
+public record Pair(Object left, Object right) { }

--- a/lib/src/main/java/com/wjduquette/joe/StandardLibrary.java
+++ b/lib/src/main/java/com/wjduquette/joe/StandardLibrary.java
@@ -1,6 +1,7 @@
 package com.wjduquette.joe;
 
 import com.wjduquette.joe.types.ErrorProxy;
+import com.wjduquette.joe.types.PairProxy;
 import com.wjduquette.joe.types.StringProxy;
 
 import java.util.List;
@@ -18,6 +19,7 @@ public class StandardLibrary extends Library {
         globalFunction("typeName",  this::_typeName);
 
         type(ErrorProxy.TYPE);
+        type(PairProxy.TYPE);
         type(StringProxy.TYPE);
     }
 

--- a/lib/src/main/java/com/wjduquette/joe/StandardLibrary.java
+++ b/lib/src/main/java/com/wjduquette/joe/StandardLibrary.java
@@ -26,22 +26,22 @@ public class StandardLibrary extends Library {
     //**
     // @global catch
     // @args callable
-    // @returns error or null
-    // Executes the callable, which must not require any arguments,
+    // @returns Pair(result, error)
+    // Executes the callable, which must not require any arguments.
     // and returns `null` if the call succeeds and the error otherwise.
     //
-    // This is a preliminary implementation of `catch`.  Ultimately
-    // it needs to return a `Pair(ok,error)`.
+    // Returns `Pair(result, null)` on success and
+    // `Pair(null, Error)` on error.
     private Object _catch(Joe joe, List<Object> args) {
         Joe.exactArity(args, 1, "catch(callable)");
         var arg = args.get(0);
 
         if (arg instanceof JoeCallable callable) {
             try {
-                callable.call(joe, List.of());
-                return null;
+                var result = callable.call(joe, List.of());
+                return new Pair(result, null);
             } catch (JoeError ex) {
-                return ex;
+                return new Pair(null, ex);
             }
         } else {
             throw joe.expected("no-argument callable", arg);

--- a/lib/src/main/java/com/wjduquette/joe/StandardLibrary.java
+++ b/lib/src/main/java/com/wjduquette/joe/StandardLibrary.java
@@ -1,5 +1,8 @@
 package com.wjduquette.joe;
 
+import com.wjduquette.joe.types.ErrorProxy;
+import com.wjduquette.joe.types.StringProxy;
+
 import java.util.List;
 
 public class StandardLibrary extends Library {
@@ -13,6 +16,9 @@ public class StandardLibrary extends Library {
         globalFunction("println",   this::_println);
         globalFunction("stringify", this::_stringify);
         globalFunction("typeName",  this::_typeName);
+
+        type(ErrorProxy.TYPE);
+        type(StringProxy.TYPE);
     }
 
     //**

--- a/lib/src/main/java/com/wjduquette/joe/TypeProxy.java
+++ b/lib/src/main/java/com/wjduquette/joe/TypeProxy.java
@@ -7,31 +7,100 @@ import java.util.*;
  * metadata and services for the type.
  * @param <V> The native value type
  */
-public class TypeProxy<V> {
+public class TypeProxy<V> implements JoeCallable {
     //-------------------------------------------------------------------------
     // Instance Variables
 
     private final String typeName;
     private final Set<Class<? extends V>> proxiedTypes = new HashSet<>();
+    private NativeFunction initializer = null;
     private final Map<String, JoeValueCallable<V>> methods = new HashMap<>();
 
     //-------------------------------------------------------------------------
     // Constructor
 
+    /**
+     * Creates a type proxy for value type V.  The name is the script-level
+     * name for the type, which need not match V's simple name.
+     * @param name The name
+     */
     public TypeProxy(String name) {
         this.typeName = name;
     }
 
-
     //-------------------------------------------------------------------------
     // Type Builders
 
+    /**
+     * Declares that this proxy is a proxy for the given type, which should
+     * be a real class (not an interface) that is assignable to the value
+     * type.
+     *
+     * A proxy can proxy any number of related types.
+     * @param type The proxied type.
+     */
     public void proxies(Class<? extends V> type) {
         proxiedTypes.add(type);
     }
 
+    /**
+     * Defines an initializer for this type.  This defines a global
+     * function named after the type.
+     * @param callable The callable
+     */
+    public void initializer(JoeCallable callable) {
+        this.initializer = new NativeFunction(typeName, callable);
+    }
+
+    /**
+     * Defines a method for the type.
+     * @param name The method name
+     * @param callable The value callable that implements the method.
+     */
     public void method(String name, JoeValueCallable<V> callable) {
         methods.put(name, callable);
+    }
+
+    //-------------------------------------------------------------------------
+    // Overridable methods
+
+    /**
+     * Returns a stringified value, i.e., a value for display.
+     * Defaults to the value's toString().
+     * @param joe The engine
+     * @param value The value
+     * @return The string
+     */
+    public String stringify(Joe joe, V value) {
+        return value.toString();
+    }
+
+    /**
+     * Returns a codified value, i.e., a value as it could be entered
+     * in code, or a "<...>" token otherwise.
+     * Defaults to the value's toString().
+     * @param joe The engine
+     * @param value The value
+     * @return The string
+     */
+    public String codify(Joe joe, V value) {
+        return value.toString();
+    }
+
+    //-------------------------------------------------------------------------
+    // Initializer implementation
+
+    @Override
+    public Object call(Joe joe, List<Object> args) {
+        if (initializer != null) {
+            return initializer.call(joe, args);
+        } else if (methods.isEmpty()) {
+            throw new JoeError("Type " + typeName +
+                " is static and cannot be initialized.");
+        } else {
+            throw new JoeError("Type " + typeName +
+                " cannot be instantiated at the script level.");
+        }
     }
 
     //-------------------------------------------------------------------------
@@ -64,12 +133,22 @@ public class TypeProxy<V> {
     //-------------------------------------------------------------------------
     // Public Methods
 
-    public String getTypeName() {
+    /**
+     * Gets the type's script-level name, which might not match its
+     * Java name.
+     * @return The name
+     */
+    public final String getTypeName() {
         return typeName;
     }
 
-    public Set<Class<?>> getProxiedTypes() {
+    /**
+     * Gets the Java types proxied by this type.  These should be
+     * actual classes, not interfaces, that are assignable to the
+     * value type.
+     * @return The proxied types.
+     */
+    public final Set<Class<?>> getProxiedTypes() {
         return Collections.unmodifiableSet(proxiedTypes);
     }
-
 }

--- a/lib/src/main/java/com/wjduquette/joe/TypeProxy.java
+++ b/lib/src/main/java/com/wjduquette/joe/TypeProxy.java
@@ -36,7 +36,7 @@ public class TypeProxy<V> implements JoeCallable {
      * be a real class (not an interface) that is assignable to the value
      * type.
      *
-     * A proxy can proxy any number of related types.
+     * <p>A proxy can proxy any number of related types.</p>
      * @param type The proxied type.
      */
     public void proxies(Class<? extends V> type) {
@@ -71,7 +71,7 @@ public class TypeProxy<V> implements JoeCallable {
      * @param value The value
      * @return The string
      */
-    public String stringify(Joe joe, V value) {
+    public String stringify(Joe joe, Object value) {
         return value.toString();
     }
 
@@ -83,7 +83,7 @@ public class TypeProxy<V> implements JoeCallable {
      * @param value The value
      * @return The string
      */
-    public String codify(Joe joe, V value) {
+    public String codify(Joe joe, Object value) {
         return value.toString();
     }
 

--- a/lib/src/main/java/com/wjduquette/joe/TypeProxy.java
+++ b/lib/src/main/java/com/wjduquette/joe/TypeProxy.java
@@ -1,0 +1,57 @@
+package com.wjduquette.joe;
+
+import java.util.*;
+
+/**
+ * A proxy for a native Java type.  The proxy implements all required
+ * metadata and services for the type.
+ * @param <V> The native value type
+ */
+public class TypeProxy<V> {
+    //-------------------------------------------------------------------------
+    // Instance Variables
+
+    private final String typeName;
+    private final Set<Class<? extends V>> proxiedTypes = new HashSet<>();
+    private final Map<String, JoeValueCallable<V>> methods = new HashMap<>();
+
+    //-------------------------------------------------------------------------
+    // Constructor
+
+    public TypeProxy(String name) {
+        this.typeName = name;
+    }
+
+
+    //-------------------------------------------------------------------------
+    // Type Builders
+
+    public void proxies(Class<? extends V> type) {
+        proxiedTypes.add(type);
+    }
+
+    public void method(String name, JoeValueCallable<V> callable) {
+        methods.put(name, callable);
+    }
+
+    //-------------------------------------------------------------------------
+    // Internal Methods
+
+    //-------------------------------------------------------------------------
+    // Public Methods
+
+    public Set<Class<?>> getProxiedTypes() {
+        return Collections.unmodifiableSet(proxiedTypes);
+    }
+
+    public JoeCallable findMethod(Object value, String name) {
+        var method = methods.get(name);
+
+        // TODO: Consider allowing method chaining
+        if (method != null) {
+            return (joe, args) -> method.call((V)value, joe, args);
+        } else {
+            throw new JoeError("Undefined property '" + name + "'.");
+        }
+    }
+}

--- a/lib/src/main/java/com/wjduquette/joe/TypeProxy.java
+++ b/lib/src/main/java/com/wjduquette/joe/TypeProxy.java
@@ -37,14 +37,20 @@ public class TypeProxy<V> {
     //-------------------------------------------------------------------------
     // Internal Methods
 
-    //-------------------------------------------------------------------------
-    // Public Methods
-
-    public Set<Class<?>> getProxiedTypes() {
-        return Collections.unmodifiableSet(proxiedTypes);
-    }
-
-    public JoeCallable findMethod(Object value, String name) {
+    /**
+     * Given an object, which *must* be assignable to the value type, and a
+     * method name, returns a callable that binds the method's callable to
+     * the object.
+     *
+     * <p><b>NOTE:</b> this is intended for use in Interpreter, which will
+     * find the proxy via Joe::lookupProxy; hence, this is type-safe.</p>
+     * @param value The value
+     * @param name The method name
+     * @return The bound callable
+     * @throws JoeError if the method is not found.
+     */
+    @SuppressWarnings("unchecked")
+    JoeCallable bind(Object value, String name) {
         var method = methods.get(name);
 
         // TODO: Consider allowing method chaining
@@ -54,4 +60,16 @@ public class TypeProxy<V> {
             throw new JoeError("Undefined property '" + name + "'.");
         }
     }
+
+    //-------------------------------------------------------------------------
+    // Public Methods
+
+    public String getTypeName() {
+        return typeName;
+    }
+
+    public Set<Class<?>> getProxiedTypes() {
+        return Collections.unmodifiableSet(proxiedTypes);
+    }
+
 }

--- a/lib/src/main/java/com/wjduquette/joe/TypeProxy.java
+++ b/lib/src/main/java/com/wjduquette/joe/TypeProxy.java
@@ -78,13 +78,13 @@ public class TypeProxy<V> implements JoeCallable {
     /**
      * Returns a codified value, i.e., a value as it could be entered
      * in code, or a "<...>" token otherwise.
-     * Defaults to the value's toString().
+     * Defaults to the stringified value.
      * @param joe The engine
      * @param value The value
      * @return The string
      */
     public String codify(Joe joe, Object value) {
-        return value.toString();
+        return stringify(joe, value);
     }
 
     //-------------------------------------------------------------------------

--- a/lib/src/main/java/com/wjduquette/joe/tools/test/TestTool.java
+++ b/lib/src/main/java/com/wjduquette/joe/tools/test/TestTool.java
@@ -117,7 +117,7 @@ public class TestTool implements Tool {
         }
 
         // NEXT, execute its tests.
-        var globals = joe.getGlobalEnvironment();
+        var globals = joe.getGlobals();
         var tests = globals.getVarNames().stream()
             .filter(name -> name.startsWith("test"))
             .toList();

--- a/lib/src/main/java/com/wjduquette/joe/tools/test/TestTool.java
+++ b/lib/src/main/java/com/wjduquette/joe/tools/test/TestTool.java
@@ -95,7 +95,7 @@ public class TestTool implements Tool {
     }
 
     private void runTest(String scriptPath) {
-        System.out.println("Running: " + scriptPath);
+        System.out.println("\nRunning: " + scriptPath);
 
         // FIRST, load the script.
         try {
@@ -122,10 +122,18 @@ public class TestTool implements Tool {
             .filter(name -> name.startsWith("test"))
             .toList();
 
+        if (tests.isEmpty()) {
+            println("  No tests in file.");
+            return;
+        }
+
+        println();
+
         for (var test : tests) {
             var value = globals.getVar(test);
             if (value instanceof JoeCallable callable) {
-                println(test + " in file " + scriptPath);
+                System.out.printf("%-30s in file %s\n", test, scriptPath);
+
                 try {
                     callable.call(joe, List.of());
                     ++successCount;

--- a/lib/src/main/java/com/wjduquette/joe/types/ErrorProxy.java
+++ b/lib/src/main/java/com/wjduquette/joe/types/ErrorProxy.java
@@ -2,6 +2,7 @@ package com.wjduquette.joe.types;
 
 import com.wjduquette.joe.Joe;
 import com.wjduquette.joe.JoeError;
+import com.wjduquette.joe.Pair;
 import com.wjduquette.joe.TypeProxy;
 
 import java.util.List;
@@ -17,6 +18,15 @@ public class ErrorProxy extends TypeProxy<JoeError> {
 
         proxies(JoeError.class);
         method("message", this::_message);
+        method("type",    this::_type);
+    }
+
+    @Override
+    public String stringify(Joe joe, Object value) {
+        assert value instanceof JoeError;
+        var err = (JoeError)value;
+        return "Error[type=" + err.getClass().getSimpleName()
+            + ", message='" + joe.codify(err.getMessage()) + "']";
     }
 
     //-------------------------------------------------------------------------
@@ -29,5 +39,14 @@ public class ErrorProxy extends TypeProxy<JoeError> {
     private Object _message(JoeError error, Joe joe, List<Object> args) {
         Joe.exactArity(args, 0, "message()");
         return error.getMessage();
+    }
+
+    //**
+    // @method type
+    // @returns The name
+    // Gets the name of the concrete error type.
+    private Object _type(JoeError error, Joe joe, List<Object> args) {
+        Joe.exactArity(args, 0, "type()");
+        return error.getClass().getSimpleName();
     }
 }

--- a/lib/src/main/java/com/wjduquette/joe/types/ErrorProxy.java
+++ b/lib/src/main/java/com/wjduquette/joe/types/ErrorProxy.java
@@ -2,7 +2,6 @@ package com.wjduquette.joe.types;
 
 import com.wjduquette.joe.Joe;
 import com.wjduquette.joe.JoeError;
-import com.wjduquette.joe.Pair;
 import com.wjduquette.joe.TypeProxy;
 
 import java.util.List;

--- a/lib/src/main/java/com/wjduquette/joe/types/ErrorProxy.java
+++ b/lib/src/main/java/com/wjduquette/joe/types/ErrorProxy.java
@@ -1,0 +1,33 @@
+package com.wjduquette.joe.types;
+
+import com.wjduquette.joe.Joe;
+import com.wjduquette.joe.JoeError;
+import com.wjduquette.joe.TypeProxy;
+
+import java.util.List;
+
+public class ErrorProxy extends TypeProxy<JoeError> {
+    public static final ErrorProxy TYPE = new ErrorProxy();
+
+    //-------------------------------------------------------------------------
+    // Constructor
+
+    public ErrorProxy() {
+        super("Error");
+
+        proxies(JoeError.class);
+        method("message", this::_message);
+    }
+
+    //-------------------------------------------------------------------------
+    // Method Implementations
+
+    //**
+    // @method message
+    // @returns The message [[String]]
+    // Gets the actual error message
+    private Object _message(JoeError error, Joe joe, List<Object> args) {
+        Joe.exactArity(args, 0, "message()");
+        return error.getMessage();
+    }
+}

--- a/lib/src/main/java/com/wjduquette/joe/types/PairProxy.java
+++ b/lib/src/main/java/com/wjduquette/joe/types/PairProxy.java
@@ -1,0 +1,75 @@
+package com.wjduquette.joe.types;
+
+import com.wjduquette.joe.Joe;
+import com.wjduquette.joe.Pair;
+import com.wjduquette.joe.TypeProxy;
+
+import java.util.List;
+
+public class PairProxy extends TypeProxy<Pair> {
+    public static final PairProxy TYPE = new PairProxy();
+
+    //-------------------------------------------------------------------------
+    // Constructor
+
+    public PairProxy() {
+        super("Pair");
+
+        proxies(Pair.class);
+
+        initializer(this::_init);
+
+        method("left",  this::_left);
+        method("right", this::_right);
+    }
+
+    //-------------------------------------------------------------------------
+    // Overridable methods
+
+    @Override
+    public String stringify(Joe joe, Pair value) {
+        return "Pair("
+            + joe.stringify(value.left())
+            + ", "
+            + joe.stringify(value.right())
+            + ")";
+    }
+
+    @Override
+    public String codify(Joe joe, Pair value) {
+        return "Pair("
+            + joe.codify(value.left())
+            + ", "
+            + joe.codify(value.right())
+            + ")";
+    }
+
+    //-------------------------------------------------------------------------
+    // Initializer
+
+    public Object _init(Joe joe, List<Object> args) {
+        Joe.exactArity(args, 2, "Pair(left, right)");
+        return new Pair(args.get(0), args.get(1));
+    }
+
+    //-------------------------------------------------------------------------
+    // Method Implementations
+
+    //**
+    // @method left
+    // @returns The left-hand value
+    // Gets the first value in the pair.
+    private Object _left(Pair value, Joe joe, List<Object> args) {
+        Joe.exactArity(args, 0, "left()");
+        return value.left();
+    }
+
+    //**
+    // @method right
+    // @returns The right-hand value
+    // Gets the second value in the pair.
+    private Object _right(Pair value, Joe joe, List<Object> args) {
+        Joe.exactArity(args, 0, "right()");
+        return value.right();
+    }
+}

--- a/lib/src/main/java/com/wjduquette/joe/types/PairProxy.java
+++ b/lib/src/main/java/com/wjduquette/joe/types/PairProxy.java
@@ -27,20 +27,24 @@ public class PairProxy extends TypeProxy<Pair> {
     // Overridable methods
 
     @Override
-    public String stringify(Joe joe, Pair value) {
+    public String stringify(Joe joe, Object value) {
+        assert value instanceof Pair;
+        var pair = (Pair)value;
         return "Pair("
-            + joe.stringify(value.left())
+            + joe.stringify(pair.left())
             + ", "
-            + joe.stringify(value.right())
+            + joe.stringify(pair.right())
             + ")";
     }
 
     @Override
-    public String codify(Joe joe, Pair value) {
+    public String codify(Joe joe, Object value) {
+        assert value instanceof Pair;
+        var pair = (Pair)value;
         return "Pair("
-            + joe.codify(value.left())
+            + joe.codify(pair.left())
             + ", "
-            + joe.codify(value.right())
+            + joe.codify(pair.right())
             + ")";
     }
 

--- a/lib/src/main/java/com/wjduquette/joe/types/StringProxy.java
+++ b/lib/src/main/java/com/wjduquette/joe/types/StringProxy.java
@@ -1,7 +1,6 @@
 package com.wjduquette.joe.types;
 
 import com.wjduquette.joe.Joe;
-import com.wjduquette.joe.JoeError;
 import com.wjduquette.joe.TypeProxy;
 
 import java.util.List;

--- a/lib/src/main/java/com/wjduquette/joe/types/StringProxy.java
+++ b/lib/src/main/java/com/wjduquette/joe/types/StringProxy.java
@@ -1,0 +1,33 @@
+package com.wjduquette.joe.types;
+
+import com.wjduquette.joe.Joe;
+import com.wjduquette.joe.JoeError;
+import com.wjduquette.joe.TypeProxy;
+
+import java.util.List;
+
+public class StringProxy extends TypeProxy<String> {
+    public static final StringProxy TYPE = new StringProxy();
+
+    //-------------------------------------------------------------------------
+    // Constructor
+
+    public StringProxy() {
+        super("String");
+
+        proxies(String.class);
+        method("length", this::_length);
+    }
+
+    //-------------------------------------------------------------------------
+    // Method Implementations
+
+    //**
+    // @method length
+    // @returns The string's length
+    // Gets the string's length.
+    private Object _length(String value, Joe joe, List<Object> args) {
+        Joe.exactArity(args, 0, "length()");
+        return (double)value.length();
+    }
+}

--- a/tests/test_testtool.joe
+++ b/tests/test_testtool.joe
@@ -5,13 +5,17 @@ function testAssertEquals() {
     assertEquals("abc", "abc");
 
     function bad() { assertEquals("abc", 5); }
-    var err = catch(bad);
+    var pair = catch(bad);
+    println("pair=" + codify(pair));
+    var err = pair.right();
 
     assertEquals(err.message(), "Expected '5', got: 'abc'.");
 }
 
 function testFail() {
     function bad() { fail("Simulated failure"); }
-    var err = catch(bad);
+    var pair = catch(bad);
+    println("pair=" + codify(pair));
+    var err = pair.right();
     assertEquals(err.message(), "Simulated failure");
 }

--- a/tests/test_testtool.joe
+++ b/tests/test_testtool.joe
@@ -6,7 +6,6 @@ function testAssertEquals() {
 
     function bad() { assertEquals("abc", 5); }
     var pair = catch(bad);
-    println("pair=" + codify(pair));
     var err = pair.right();
 
     assertEquals(err.message(), "Expected '5', got: 'abc'.");
@@ -15,7 +14,6 @@ function testAssertEquals() {
 function testFail() {
     function bad() { fail("Simulated failure"); }
     var pair = catch(bad);
-    println("pair=" + codify(pair));
     var err = pair.right();
     assertEquals(err.message(), "Simulated failure");
 }

--- a/tests/test_testtool.joe
+++ b/tests/test_testtool.joe
@@ -13,6 +13,5 @@ function testAssertEquals() {
 function testFail() {
     function bad() { fail("Simulated failure"); }
     var err = catch(bad);
-
     assertEquals(err.message(), "Simulated failure");
 }

--- a/tests/test_testtool.joe
+++ b/tests/test_testtool.joe
@@ -1,23 +1,18 @@
 // Sample test script
 
-howdy();
-howdy();
-howdy();
-
 function testAssertEquals() {
     assertEquals(5, 5);
     assertEquals("abc", "abc");
 
     function bad() { assertEquals("abc", 5); }
+    var err = catch(bad);
 
-    assertEquals(stringify(catch(bad)),
-        "com.wjduquette.joe.AssertError: Expected '5', got: 'abc'."
-    );
+    assertEquals(err.message(), "Expected '5', got: 'abc'.");
 }
 
 function testFail() {
     function bad() { fail("Simulated failure"); }
+    var err = catch(bad);
 
-    assertEquals(stringify(catch(bad)),
-        "com.wjduquette.joe.AssertError: Simulated failure");
+    assertEquals(err.message(), "Simulated failure");
 }


### PR DESCRIPTION
This pull request implements the ability to define `TypeProxies` for native Java types.  As of this pull question, the `TypeProxy`:

- Defines the type's initializer, if any.
- Defines the type's methods, if any.
- Defines a type-specific codifier and stringifier, as needed.

Barebones proxies are defined for `String` and `Error` (all `JoeErrors`).

The `Pair` type and its proxy are fully implemented, and are used by `catch()` to return either the successful result or the thrown error.