### PR TITLE
doc_config.joe

### DIFF
--- a/lib/src/main/java/com/wjduquette/joe/Joe.java
+++ b/lib/src/main/java/com/wjduquette/joe/Joe.java
@@ -43,6 +43,14 @@ public class Joe {
     }
 
     /**
+     * Installs a library into this interpreter.
+     * @param library The library
+     */
+    public void installLibrary(Library library) {
+        library.install(this);
+    }
+
+    /**
      * Installs a native function into Joe's global environment.
      * @param function The function
      */

--- a/lib/src/main/java/com/wjduquette/joe/tools/doc/DocConfig.java
+++ b/lib/src/main/java/com/wjduquette/joe/tools/doc/DocConfig.java
@@ -1,6 +1,8 @@
 package com.wjduquette.joe.tools.doc;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Configuration data for `joe doc`
@@ -9,6 +11,8 @@ public class DocConfig {
     //-------------------------------------------------------------------------
     // Instance Variables
 
+    private final List<Path> inputFolders = new ArrayList<>();
+    private final List<Path> inputFiles = new ArrayList<>();
     private Path outputFolder;
 
     //-------------------------------------------------------------------------
@@ -19,10 +23,17 @@ public class DocConfig {
     }
 
     //-------------------------------------------------------------------------
-    // Configuration
+    // Accessors
 
+    public List<Path> inputFolders() {
+        return inputFolders;
+    }
 
-    public Path getOutputFolder() {
+    public List<Path> inputFiles() {
+        return inputFiles;
+    }
+
+    public Path outputFolder() {
         return outputFolder;
     }
 

--- a/lib/src/main/java/com/wjduquette/joe/tools/doc/DocTool.java
+++ b/lib/src/main/java/com/wjduquette/joe/tools/doc/DocTool.java
@@ -1,5 +1,7 @@
 package com.wjduquette.joe.tools.doc;
 
+import com.wjduquette.joe.Joe;
+import com.wjduquette.joe.JoeError;
 import com.wjduquette.joe.app.App;
 import com.wjduquette.joe.tools.Tool;
 import com.wjduquette.joe.tools.ToolInfo;
@@ -28,6 +30,8 @@ public class DocTool implements Tool {
     public static final Set<String> FILE_TYPES = Set.of(
         ".java", ".joe"
     );
+
+    public static final Path DOC_CONFIG = Path.of("doc_config.joe");
 
     //-------------------------------------------------------------------------
     // Instance Variables
@@ -58,11 +62,33 @@ public class DocTool implements Tool {
             System.exit(1);
         }
 
-        // NEXT, get the input folders.
-        // NOTE: These will ultimately come from the joe_doc.monica file.
-        config.inputFolders().add(Path.of("../lib/src/main/java/com/wjduquette/joe"));
-        config.inputFolders().add(Path.of("../lib/src/main/resources/com/wjduquette/joe"));
-        config.setOutputFolder(Path.of("src/library"));
+        // NEXT, look for the doc_config file.
+        if (!Files.exists(DOC_CONFIG)) {
+            System.err.println("Could not find " + DOC_CONFIG +
+                " in the current working directory.");
+            exit(1);
+        }
+
+        var joe = new Joe();
+        joe.installLibrary(new JoeDocPackage(config));
+        try {
+            joe.runFile(DOC_CONFIG.toString());
+        } catch (IOException ex) {
+            System.err.println("Could not load " + DOC_CONFIG +
+                ": " + ex.getMessage());
+            exit(1);
+        } catch (JoeError ex) {
+            System.err.println("Error in " + DOC_CONFIG +
+                ": " + ex.getMessage());
+            exit(1);
+        }
+
+//
+//        // NEXT, get the input folders.
+//        // NOTE: These will ultimately come from the joe_doc.monica file.
+//        config.inputFolders().add(Path.of("../lib/src/main/java/com/wjduquette/joe"));
+//        config.inputFolders().add(Path.of("../lib/src/main/resources/com/wjduquette/joe"));
+//        config.setOutputFolder(Path.of("src/library"));
 
         // NEXT, populate the list of files.
         scanInputFolders();

--- a/lib/src/main/java/com/wjduquette/joe/tools/doc/DocTool.java
+++ b/lib/src/main/java/com/wjduquette/joe/tools/doc/DocTool.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -33,11 +32,8 @@ public class DocTool implements Tool {
     //-------------------------------------------------------------------------
     // Instance Variables
 
+    // The client's configuration
     private final DocConfig config = new DocConfig();
-
-    // Ultimately, these will go in DocConfig.
-    private final List<Path> inputFolders = new ArrayList<>();
-    private final List<Path> inputFiles = new ArrayList<>();
 
     //-------------------------------------------------------------------------
     // Constructor
@@ -64,15 +60,14 @@ public class DocTool implements Tool {
 
         // NEXT, get the input folders.
         // NOTE: These will ultimately come from the joe_doc.monica file.
-        inputFolders.add(Path.of("../lib/src/main/java/com/wjduquette/joe"));
-        inputFolders.add(Path.of("../lib/src/main/resources/com/wjduquette/joe"));
-//        inputFolders.add(Path.of("."));
+        config.inputFolders().add(Path.of("../lib/src/main/java/com/wjduquette/joe"));
+        config.inputFolders().add(Path.of("../lib/src/main/resources/com/wjduquette/joe"));
         config.setOutputFolder(Path.of("src/library"));
 
         // NEXT, populate the list of files.
         scanInputFolders();
 
-        if (inputFiles.isEmpty()) {
+        if (config.inputFiles().isEmpty()) {
             println("*** No files found.");
             exit();
         }
@@ -81,7 +76,7 @@ public class DocTool implements Tool {
         var docSet = new DocumentationSet();
         var parser = new DocCommentParser(docSet);
         var errors = 0;
-        for (var file : inputFiles) {
+        for (var file : config.inputFiles()) {
             try {
                 parser.parse(file);
             } catch (DocCommentParser.ParseError ex) {
@@ -104,7 +99,7 @@ public class DocTool implements Tool {
 
     private void scanInputFolders() {
         println("Scanning folders:");
-        for (var folder : inputFolders) {
+        for (var folder : config.inputFolders()) {
             println("  " + folder);
             scanFolder(folder);
         }
@@ -117,7 +112,7 @@ public class DocTool implements Tool {
         try (var stream = Files.walk(folder)) {
             stream
                 .filter(p -> FILE_TYPES.contains(fileType(p)))
-                .forEach(inputFiles::add);
+                .forEach(config.inputFiles()::add);
         } catch (IOException ex) {
             println("*** Failed to scan '" + folder + "':\n" +
                 ex.getMessage());

--- a/lib/src/main/java/com/wjduquette/joe/tools/doc/Generator.java
+++ b/lib/src/main/java/com/wjduquette/joe/tools/doc/Generator.java
@@ -40,7 +40,7 @@ class Generator {
      */
     public void generate() {
         // FIRST, generate the index file.
-        write(config.getOutputFolder().resolve(DOC_SET_INDEX),
+        write(config.outputFolder().resolve(DOC_SET_INDEX),
             this::writeDocSetIndex);
 
         // NEXT, generate the files for each package, in order.
@@ -50,12 +50,12 @@ class Generator {
             populateShortTable(pkg);
 
             // NEXT, write the package file
-            write(config.getOutputFolder().resolve(pkg.filename()),
+            write(config.outputFolder().resolve(pkg.filename()),
                 out -> writePackageFile(out, pkg));
 
             // NEXT, write each type file
             for (var type : sorted(pkg.types(), TypeEntry::name)) {
-                write(config.getOutputFolder().resolve(type.filename()),
+                write(config.outputFolder().resolve(type.filename()),
                     out -> writeTypeFile(out, type));
             }
         }

--- a/lib/src/main/java/com/wjduquette/joe/tools/doc/JoeDocPackage.java
+++ b/lib/src/main/java/com/wjduquette/joe/tools/doc/JoeDocPackage.java
@@ -1,0 +1,93 @@
+package com.wjduquette.joe.tools.doc;
+
+import com.wjduquette.joe.*;
+
+import java.nio.file.Path;
+
+public class JoeDocPackage extends Library {
+    public static final JoeDocPackage PACKAGE = new JoeDocPackage();
+
+    public JoeDocPackage() {
+        super();
+
+        //**
+        // @package joe.doc
+        // @title JoeDoc Configuration API
+        // The `joe.doc` package contains the Joe API used in
+        // the `joe doc` configuration file, `doc_config.joe`.
+    }
+
+    private static class DocConfigProxy extends TypeProxy<Void> {
+        //---------------------------------------------------------------------
+        // Instance Variables
+
+        private final DocConfig config;
+
+        //---------------------------------------------------------------------
+        // Constructor
+
+        //**
+        // @type DocConfig
+        // The `DocConfig` static type owns the static methods used to
+        // configure the `joe doc` tool.
+        public DocConfigProxy(DocConfig config) {
+            super("DocConfig");
+            this.config = config;
+            staticType();
+
+            staticMethod("inputFile",    this::_inputFile);
+            staticMethod("inputFolder",  this::_inputFolder);
+            staticMethod("outputFolder", this::_outputFolder);
+        }
+
+        //**
+        // @static inputFile
+        // @args filename,...
+        // @result this
+        // Adds the paths of one or more files to scan for JoeDoc
+        // comments.  File paths are relative to the location of the
+        // `doc_config.joe` file.
+        private Object _inputFile(Joe joe, ArgQueue args) {
+            Joe.minArity(args, 1, "inputFile(filename, ...)");
+
+            for (var name : args.asList()) {
+                config.inputFiles().add(Path.of(joe.toString(name)));
+            }
+            return this;
+        }
+
+        //**
+        // @static inputFolder
+        // @args folder,...
+        // @result this
+        // Adds the paths of one or more folders to scan for files
+        // containing JoeDoc comments. `joe doc` will scan all
+        // `.java` and `.joe` files in the folders, recursing down
+        // into subfolders.
+        //
+        // Folder paths are relative to the location of the
+        // `doc_config.joe` file.
+        private Object _inputFolder(Joe joe, ArgQueue args) {
+            Joe.minArity(args, 1, "inputFolder(folder, ...)");
+
+            for (var name : args.asList()) {
+                config.inputFolders().add(Path.of(joe.toString(name)));
+            }
+            return this;
+        }
+
+        //**
+        // @static outputFolder
+        // @args folder
+        // @result this
+        // Sets the name of the folder to receive the generated outputs.
+        // If unset, defaults to the folder containing the `doc_config.joe`
+        // file.
+        private Object _outputFolder(Joe joe, ArgQueue args) {
+            Joe.exactArity(args, 1, "outputFolder(folder)");
+
+            config.setOutputFolder(Path.of(joe.toString(args.next())));
+            return this;
+        }
+    }
+}

--- a/lib/src/main/java/com/wjduquette/joe/tools/doc/JoeDocPackage.java
+++ b/lib/src/main/java/com/wjduquette/joe/tools/doc/JoeDocPackage.java
@@ -5,23 +5,23 @@ import com.wjduquette.joe.*;
 import java.nio.file.Path;
 
 public class JoeDocPackage extends Library {
-    public static final JoeDocPackage PACKAGE = new JoeDocPackage();
+    private final DocConfig config;
 
-    public JoeDocPackage() {
+    //**
+    // @package joe.doc
+    // @title JoeDoc Configuration API
+    // The `joe.doc` package contains the Joe API used in
+    // the `joe doc` configuration file, `doc_config.joe`.
+    public JoeDocPackage(DocConfig config) {
         super();
-
-        //**
-        // @package joe.doc
-        // @title JoeDoc Configuration API
-        // The `joe.doc` package contains the Joe API used in
-        // the `joe doc` configuration file, `doc_config.joe`.
+        this.config = config;
+        type(new DocConfigProxy());
     }
 
-    private static class DocConfigProxy extends TypeProxy<Void> {
+    private class DocConfigProxy extends TypeProxy<Void> {
         //---------------------------------------------------------------------
         // Instance Variables
 
-        private final DocConfig config;
 
         //---------------------------------------------------------------------
         // Constructor
@@ -30,9 +30,8 @@ public class JoeDocPackage extends Library {
         // @type DocConfig
         // The `DocConfig` static type owns the static methods used to
         // configure the `joe doc` tool.
-        public DocConfigProxy(DocConfig config) {
+        public DocConfigProxy() {
             super("DocConfig");
-            this.config = config;
             staticType();
 
             staticMethod("inputFile",    this::_inputFile);

--- a/mdbook/doc_config.joe
+++ b/mdbook/doc_config.joe
@@ -1,0 +1,5 @@
+// Configuration for the Joe library docs
+DocConfig
+    .inputFolder("../lib/src/main/java/com/wjduquette/joe")
+    .inputFolder("../lib/src/main/resources/com/wjduquette/joe")
+    .outputFolder("src/library");

--- a/mdbook/src/SUMMARY.md
+++ b/mdbook/src/SUMMARY.md
@@ -24,6 +24,8 @@
   - [Joe Test Tool API](./library/pkg.joe.test.md)
     - [CatchChecker Type](./library/type.joe.test.CatchChecker.md)
     - [ValueChecker Type](./library/type.joe.test.ValueChecker.md)
+  - [JoeDoc Configuration API](./library/pkg.joe.doc.md)
+    - [DocConfig Type](./library/type.joe.doc.DocConfig.md)
   - [Library API Index](./library/index.md)
 
 


### PR DESCRIPTION
As of this pull request, `joe doc` reads its configuration from the file
`doc_config.joe`, which must be found in the current working directory.  See the JUG for the config file API.