### PR TITLE
`BertClass` can extend any `JoeClass` that `canBeExtended()`

### DIFF
--- a/lib/src/main/java/com/wjduquette/joe/JoeCallable.java
+++ b/lib/src/main/java/com/wjduquette/joe/JoeCallable.java
@@ -12,4 +12,28 @@ package com.wjduquette.joe;
  * engine can never be used with a different engine.</p>
  */
 public interface JoeCallable {
+    /**
+     * Gets the type of the callable, e.g., "function", for use in
+     * error messages, stack traces, etc.
+     * @return The type string
+     */
+    String callableType();
+
+    /**
+     * Gets the signature of the callable, e.g., "myName(a, b, c)", for use in
+     * error messages, stack traces, etc.
+     * @return The signature string
+     */
+    String signature();
+
+    /**
+     * Returns true if the callable is scripted, and false if it is native.
+     * @return true or false;
+     */
+    boolean isScripted();
+
+    /**
+     * Returns true if the callable is native, and false if it is scripted.
+     */
+    default boolean isNative() { return !isScripted(); }
 }

--- a/lib/src/main/java/com/wjduquette/joe/JoeClass.java
+++ b/lib/src/main/java/com/wjduquette/joe/JoeClass.java
@@ -19,7 +19,7 @@ public interface JoeClass extends JoeCallable {
      * @param name The method name
      * @return The bound callable
      */
-    NativeCallable bind(Object value, String name);
+    JoeCallable bind(Object value, String name);
 
     /**
      * Whether or not this class can be extended by a subclass.

--- a/lib/src/main/java/com/wjduquette/joe/JoeClass.java
+++ b/lib/src/main/java/com/wjduquette/joe/JoeClass.java
@@ -1,6 +1,6 @@
 package com.wjduquette.joe;
 
-public interface JoeClass extends NativeCallable {
+public interface JoeClass extends JoeCallable {
     /**
      * The name for a class's initializer method.
      */

--- a/lib/src/main/java/com/wjduquette/joe/JoeError.java
+++ b/lib/src/main/java/com/wjduquette/joe/JoeError.java
@@ -1,5 +1,7 @@
 package com.wjduquette.joe;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -186,6 +188,17 @@ public class JoeError extends RuntimeException {
         } else {
             return getMessage() + "\n" + getTraceReport().indent(2);
         }
+    }
+
+    /**
+     * Gets the Java stack trace for this exception.
+     * @return The trace.
+     */
+    public String getJavaStackTrace() {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintStream recordingStream = new PrintStream(baos);
+        printStackTrace(recordingStream);
+        return baos.toString();
     }
 
     //-------------------------------------------------------------------------

--- a/lib/src/main/java/com/wjduquette/joe/NativeCallable.java
+++ b/lib/src/main/java/com/wjduquette/joe/NativeCallable.java
@@ -13,28 +13,4 @@ public interface NativeCallable extends JoeCallable {
      */
     Object call(Joe joe, Args args);
 
-    /**
-     * Gets the type of the callable, e.g., "function", for use in
-     * error messages, stack traces, etc.
-     * @return The type string
-     */
-    String callableType();
-
-    /**
-     * Gets the signature of the callable, e.g., "myName(a, b, c)", for use in
-     * error messages, stack traces, etc.
-     * @return The signature string
-     */
-    String signature();
-
-    /**
-     * Returns true if the callable is scripted, and false if it is native.
-     * @return true or false;
-     */
-    boolean isScripted();
-
-    /**
-     * Returns true if the callable is native, and false if it is scripted.
-     */
-    default boolean isNative() { return !isScripted(); }
 }

--- a/lib/src/main/java/com/wjduquette/joe/TypeProxy.java
+++ b/lib/src/main/java/com/wjduquette/joe/TypeProxy.java
@@ -8,7 +8,7 @@ import java.util.function.Function;
  * metadata and services for the type.
  * @param <V> The native value type
  */
-public class TypeProxy<V> implements JoeObject, JoeClass {
+public class TypeProxy<V> implements JoeObject, JoeClass, NativeCallable {
     //-------------------------------------------------------------------------
     // Instance Variables
 

--- a/lib/src/main/java/com/wjduquette/joe/bert/BertClass.java
+++ b/lib/src/main/java/com/wjduquette/joe/bert/BertClass.java
@@ -83,7 +83,7 @@ public class BertClass implements BertCallable, JoeClass, JoeObject {
         var method = methods.get(name);
 
         if (method != null) {
-            return new BoundMethod(this, method);
+            return new BoundMethod(value, method);
         }
 
         if (nativeAncestor != null) {

--- a/lib/src/main/java/com/wjduquette/joe/bert/BertClass.java
+++ b/lib/src/main/java/com/wjduquette/joe/bert/BertClass.java
@@ -7,6 +7,8 @@ import com.wjduquette.joe.JoeObject;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.wjduquette.joe.bert.Compiler.INIT;
+
 public class BertClass implements BertCallable, JoeObject {
     //-------------------------------------------------------------------------
     // Instance Variables
@@ -64,6 +66,29 @@ public class BertClass implements BertCallable, JoeObject {
     @Override
     public String stringify(Joe joe) {
         return "<class " + name + ">";
+    }
+
+    //-------------------------------------------------------------------------
+    // JoeCallable API
+
+    @Override
+    public String callableType() {
+        return "class";
+    }
+
+    @Override
+    public boolean isScripted() {
+        return true;
+    }
+
+    @Override
+    public String signature() {
+        var init = methods.get(INIT);
+        if (init != null) {
+            return name + init.signature().substring(4);
+        } else {
+            return name + "()";
+        }
     }
 
     //-------------------------------------------------------------------------

--- a/lib/src/main/java/com/wjduquette/joe/bert/BertInstance.java
+++ b/lib/src/main/java/com/wjduquette/joe/bert/BertInstance.java
@@ -11,7 +11,7 @@ public class BertInstance implements JoeObject {
     //-------------------------------------------------------------------------
     // Instance Variables
 
-    final BertClass klass;
+    final JoeClass klass;
     final Map<String,Object> fields = new HashMap<>();
 
     // Default "toString()" implementation.
@@ -20,7 +20,7 @@ public class BertInstance implements JoeObject {
     //-------------------------------------------------------------------------
     // Constructor
 
-    BertInstance(BertClass klass) {
+    BertInstance(JoeClass klass) {
         this.klass = klass;
         this._toString = new NativeMethod<>(this, "toString",
             (objc, joe, args) -> this.toString());
@@ -40,10 +40,10 @@ public class BertInstance implements JoeObject {
             return fields.get(name);
         }
 
-        var method = klass.methods.get(name);
+        var method = klass.bind(this, name);
 
         if (method != null) {
-            return new BoundMethod(this, method);
+            return method;
         }
 
         if (name.equals(TO_STRING)) {
@@ -62,7 +62,6 @@ public class BertInstance implements JoeObject {
     public String stringify(Joe joe) {
         var callable = get(TO_STRING);
         return (String)joe.call(callable);
-//        return toString();
     }
 
 

--- a/lib/src/main/java/com/wjduquette/joe/bert/BoundMethod.java
+++ b/lib/src/main/java/com/wjduquette/joe/bert/BoundMethod.java
@@ -4,4 +4,23 @@ package com.wjduquette.joe.bert;
  * A scripted method bound to its instance
  */
 public record BoundMethod(Object receiver, Closure method)
-    implements BertCallable { }
+    implements BertCallable
+{
+    //-------------------------------------------------------------------------
+    // JoeCallable API
+
+    @Override
+    public String callableType() {
+        return method.callableType();
+    }
+
+    @Override
+    public boolean isScripted() {
+        return true;
+    }
+
+    @Override
+    public String signature() {
+        return method.signature();
+    }
+}

--- a/lib/src/main/java/com/wjduquette/joe/bert/Closure.java
+++ b/lib/src/main/java/com/wjduquette/joe/bert/Closure.java
@@ -42,6 +42,23 @@ public class Closure implements BertCallable, JoeObject {
             "Values of type <function> have no properties.");
     }
 
+    //-------------------------------------------------------------------------
+    // JoeCallable API
+
+    @Override
+    public String callableType() {
+        return function.type().text();
+    }
+
+    @Override
+    public boolean isScripted() {
+        return true;
+    }
+
+    @Override
+    public String signature() {
+        return function.signature();
+    }
 
     //-------------------------------------------------------------------------
     // Object API

--- a/lib/src/main/java/com/wjduquette/joe/bert/VirtualMachine.java
+++ b/lib/src/main/java/com/wjduquette/joe/bert/VirtualMachine.java
@@ -345,14 +345,6 @@ class VirtualMachine {
                     push((double)a + 1);
                 }
                 case INHERIT -> {
-//                    var superclass = peek(1);
-//                    if (!(superclass instanceof BertClass)) {
-//                        throw error("Expected superclass, got: " +
-//                            joe.typedValue(superclass));
-//                    }
-//                    var subclass = (BertClass)peek(0);
-//                    subclass.methods.putAll(((BertClass)superclass).methods);
-//                    pop();  // Subclass
                     var superclass = peek(1);
 
                     if (superclass instanceof JoeClass jc) {
@@ -537,15 +529,9 @@ class VirtualMachine {
                     push((double)a - (double)b);
                 }
                 case SUPGET -> {
-//                    var name = readString();
-//                    var superclass = (BertClass)pop();
-//                    var instance = (BertInstance)peek(0);
-//                    if (!bindMethod(superclass, instance, name)) {
-//                        throw error("Undefined property: '" + name + "'.");
-//                    }
                     var name = readString();
                     var superclass = (JoeClass)pop();
-                    var instance = (BertInstance)peek(0);
+                    var instance = (JoeObject)peek(0);
                     var method = superclass.bind(instance, name);
 
                     if (method != null) {
@@ -589,23 +575,6 @@ class VirtualMachine {
             }
         }
     }
-
-//    private boolean bindMethod(
-//        BertClass cls,
-//        BertInstance instance,
-//        String name
-//    ) {
-//        var method = cls.methods.get(name);
-//
-//        if (method != null) {
-//            var bound = new BoundMethod(instance, method);
-//            pop(); // The instance
-//            push(bound);
-//            return true;
-//        } else {
-//            return false;
-//        }
-//    }
 
     private SourceBuffer.Span ipSpan() {
         var line = frame.closure.function.line(frame.ip);
@@ -750,7 +719,7 @@ class VirtualMachine {
                 call(bound.method(), argCount, origin);
             }
             case BertClass klass -> {
-                stack[top - argCount - 1] = new BertInstance(klass);
+                stack[top - argCount - 1] = klass.make(joe, klass);
                 var initializer = klass.methods.get("init");
                 if (initializer != null) {
                     call(initializer, argCount, origin);

--- a/lib/src/main/java/com/wjduquette/joe/types/ErrorProxy.java
+++ b/lib/src/main/java/com/wjduquette/joe/types/ErrorProxy.java
@@ -28,11 +28,12 @@ public class ErrorProxy extends TypeProxy<JoeError> {
 
         initializer(this::_initializer);
 
-        method("addInfo",     this::_addInfo);
-        method("message",     this::_message);
-        method("stackTrace",  this::_stackTrace);
-        method("traces",      this::_traces);
-        method("type",        this::_type);
+        method("addInfo",         this::_addInfo);
+        method("javaStackTrace",  this::_javaStackTrace);
+        method("message",         this::_message);
+        method("stackTrace",      this::_stackTrace);
+        method("traces",          this::_traces);
+        method("type",            this::_type);
     }
 
     @Override
@@ -73,6 +74,16 @@ public class ErrorProxy extends TypeProxy<JoeError> {
     private Object _addInfo(JoeError error, Joe joe, Args args) {
         args.exactArity(1, "addInfo(message)");
         return error.addInfo(joe.stringify(args.next()));
+    }
+
+    //**
+    // @method javaStackTrace
+    // @result String
+    // Returns the complete error, including the initial error messages
+    // and all stack frames.
+    private Object _javaStackTrace(JoeError error, Joe joe, Args args) {
+        args.exactArity(0, "javaStackTrace()");
+        return error.getJavaStackTrace();
     }
 
     //**

--- a/lib/src/main/java/com/wjduquette/joe/walker/Interpreter.java
+++ b/lib/src/main/java/com/wjduquette/joe/walker/Interpreter.java
@@ -489,7 +489,7 @@ class Interpreter {
                     distance, "super");
                 JoeObject instance = (JoeObject)environment.getAt(
                     distance - 1, "this");
-                NativeCallable method =
+                JoeCallable method =
                     superclass.bind(instance, expr.method().lexeme());
 
                 if (method == null) {

--- a/lib/src/main/java/com/wjduquette/joe/walker/WalkerClass.java
+++ b/lib/src/main/java/com/wjduquette/joe/walker/WalkerClass.java
@@ -61,10 +61,10 @@ class WalkerClass implements JoeClass, JoeObject, NativeCallable {
 
     public Object call(Joe joe, Args args) {
         JoeObject instance = make(joe, this);
-        NativeCallable initializer = bind(instance, INIT);
+        JoeCallable initializer = bind(instance, INIT);
         if (initializer != null) {
             try {
-                initializer.call(joe, args);
+                joe.call(initializer, args.asArray());
             } catch (JoeError ex) {
                 throw ex.addFrame("In method " + initializer.signature());
             }
@@ -91,7 +91,7 @@ class WalkerClass implements JoeClass, JoeObject, NativeCallable {
     }
 
     @Override
-    public NativeCallable bind(Object value, String name) {
+    public JoeCallable bind(Object value, String name) {
         var method = methods.get(name);
 
         if (method != null) {

--- a/lib/src/main/java/com/wjduquette/joe/walker/WalkerClass.java
+++ b/lib/src/main/java/com/wjduquette/joe/walker/WalkerClass.java
@@ -9,7 +9,7 @@ import com.wjduquette.joe.SourceBuffer.Span;
 /**
  * A class defined in a Joe script.
  */
-class WalkerClass implements JoeClass, JoeObject {
+class WalkerClass implements JoeClass, JoeObject, NativeCallable {
     //-------------------------------------------------------------------------
     // Instance Variables
 
@@ -53,10 +53,23 @@ class WalkerClass implements JoeClass, JoeObject {
     }
 
     //-------------------------------------------------------------------------
-    // ScriptedClass API
+    // WalkerClass API
 
     public Span classSpan() {
         return classSpan;
+    }
+
+    public Object call(Joe joe, Args args) {
+        JoeObject instance = make(joe, this);
+        NativeCallable initializer = bind(instance, INIT);
+        if (initializer != null) {
+            try {
+                initializer.call(joe, args);
+            } catch (JoeError ex) {
+                throw ex.addFrame("In method " + initializer.signature());
+            }
+        }
+        return instance;
     }
 
     //-------------------------------------------------------------------------
@@ -99,20 +112,6 @@ class WalkerClass implements JoeClass, JoeObject {
 
     //-------------------------------------------------------------------------
     // JoeCallable API
-
-    @Override
-    public Object call(Joe joe, Args args) {
-        JoeObject instance = make(joe, this);
-        NativeCallable initializer = bind(instance, INIT);
-        if (initializer != null) {
-            try {
-                initializer.call(joe, args);
-            } catch (JoeError ex) {
-                throw ex.addFrame("In method " + initializer.signature());
-            }
-        }
-        return instance;
-    }
 
     @Override
     public String callableType() {

--- a/lib/src/main/java/com/wjduquette/joe/walker/WalkerClass.java
+++ b/lib/src/main/java/com/wjduquette/joe/walker/WalkerClass.java
@@ -79,7 +79,7 @@ class WalkerClass implements JoeClass, JoeObject, NativeCallable {
     @Override
     public JoeObject make(Joe joe, JoeClass joeClass) {
         if (superclass != null) {
-            return superclass.make(joe, this);
+            return superclass.make(joe, joeClass);
         } else {
             return new WalkerInstance(joeClass);
         }

--- a/lib/src/main/java/com/wjduquette/joe/walker/WalkerInstance.java
+++ b/lib/src/main/java/com/wjduquette/joe/walker/WalkerInstance.java
@@ -34,7 +34,8 @@ class WalkerInstance implements JoeObject {
             return fields.get(name);
         }
 
-        NativeCallable method = joeClass.bind(this, name);
+        JoeCallable method = joeClass.bind(this, name);
+
         if (method != null) return method;
 
         if (name.equals(TO_STRING)) {

--- a/lib/src/test/java/com/wjduquette/joe/JoeTest.java
+++ b/lib/src/test/java/com/wjduquette/joe/JoeTest.java
@@ -188,6 +188,8 @@ public class JoeTest extends Ted {
                 002     method init(x) {
                 003         throw "Simulated error!";
                 004     }
+              In java call(<method init(x)>, 0)
+              In method init(x) (*test*:3)
               In class Thing(x) (*test*:3)
               In function make(x) (*test*:7)
               In <script> (*test*:9)

--- a/lib/src/test/java/com/wjduquette/joe/JoeTest.java
+++ b/lib/src/test/java/com/wjduquette/joe/JoeTest.java
@@ -10,6 +10,8 @@ public class JoeTest extends Ted {
     private Joe joe;
 
     @Before public void setup() {
+        // TODO: Need to test both Walker and Bert.
+        // When unifying stack trace behavior.
         this.joe = new Joe();
     }
 

--- a/tests/type.joe.TextBuilder.joe
+++ b/tests/type.joe.TextBuilder.joe
@@ -60,7 +60,6 @@ function testFields() {
 // Subclassing
 
 function testSubclass_canExtend() {
-    if (engine() == "bert") skip("JoeClass-integration required.");
     class Buff extends TextBuilder {
         method init(leader) {
             this.leader = leader;
@@ -75,7 +74,6 @@ function testSubclass_canExtend() {
 }
 
 function testSubclass_canUseSuper() {
-    if (engine() == "bert") skip("JoeClass-integration required.");
     class Buff extends TextBuilder {
         method println(text) {
             super.println(text);


### PR DESCRIPTION
This pull request extends `BertEngine` so that a `BertClass` can extend any `JoeClass`
that `canBeExtended()`.  This change brings the `BertEngine` into parity with the `WalkerEngine` 
regarding Joe's semantics.