### PR TITLE
Joe defaults to using the Bert byte-engine.

### DIFF
--- a/lib/src/main/java/com/wjduquette/joe/Joe.java
+++ b/lib/src/main/java/com/wjduquette/joe/Joe.java
@@ -45,6 +45,7 @@ public class Joe {
     //-------------------------------------------------------------------------
     // Instance Variables
 
+    private final String engineName;
     private final Engine engine;
     private boolean debug = false;
 
@@ -76,6 +77,7 @@ public class Joe {
      * nothing else.</p>
      */
     public Joe(String engineType) {
+        this.engineName = engineType;
         switch (engineType) {
             case WALKER -> engine = new WalkerEngine(this);
             case BERT -> engine = new BertEngine(this);
@@ -213,6 +215,14 @@ public class Joe {
      */
     public void setDebug(boolean flag) {
         this.debug = flag;
+    }
+
+    /**
+     * Gets the name of the execution engine.
+     * @return The name.
+     */
+    public String engineName() {
+        return engineName;
     }
 
     //-------------------------------------------------------------------------

--- a/lib/src/main/java/com/wjduquette/joe/Joe.java
+++ b/lib/src/main/java/com/wjduquette/joe/Joe.java
@@ -64,7 +64,7 @@ public class Joe {
      * standard library, but nothing else.
      */
     public Joe() {
-        this(WALKER);
+        this(BERT);
     }
 
     /**

--- a/lib/src/main/java/com/wjduquette/joe/app/App.java
+++ b/lib/src/main/java/com/wjduquette/joe/app/App.java
@@ -6,6 +6,8 @@ import com.wjduquette.joe.tools.test.TestTool;
 import com.wjduquette.joe.tools.ToolLauncher;
 
 import java.util.List;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
 
 /**
  * The top-level class for Joe's command-line tool.
@@ -17,6 +19,33 @@ public class App {
      * The expected name of Joe's command-lien app.
      */
     public static final String NAME = "joe";
+
+    /**
+     * Gets Joe's version number, or "?.?.?" if unavailable.
+     * @return The version number.
+     */
+    public static String getVersion() {
+        var attrs = getManifestAttributes();
+        if (attrs != null) {
+            var version = attrs.getValue("Implementation-Version");
+            if (version != null) {
+                return version;
+            }
+        }
+        return "?.?.?";
+    }
+
+    /**
+     * Get the manifest attributes, or return null on failure.
+     * @return The attributes, or null.
+     */
+    public static Attributes getManifestAttributes() {
+        try (var stream = App.class.getResourceAsStream("/META-INF/MANIFEST.MF")) {
+            return new Manifest(stream).getMainAttributes();
+        } catch (Exception ex) {
+            return null;
+        }
+    }
 
     //-------------------------------------------------------------------------
     // Main

--- a/lib/src/main/java/com/wjduquette/joe/app/DumpTool.java
+++ b/lib/src/main/java/com/wjduquette/joe/app/DumpTool.java
@@ -24,7 +24,8 @@ public class DumpTool implements Tool {
         Dumps compilation details for the script.  The options
         are as follows:
         
-        --bert, -b     Use the experimental "Bert" byte-engine.
+        --bert,   -b   Use the "Bert" byte-engine (default)
+        --walker, -w   Use the "Walker" AST-walker engine.
         """,
         DumpTool::main
     );
@@ -56,12 +57,13 @@ public class DumpTool implements Tool {
             System.exit(64);
         }
 
-        var engineType = Joe.WALKER;
+        var engineType = Joe.BERT;
 
         while (!argq.isEmpty() && argq.peek().startsWith("-")) {
             var opt = argq.poll();
             switch (opt) {
                 case "--bert", "-b" -> engineType = Joe.BERT;
+                case "--walker", "-w" -> engineType = Joe.WALKER;
                 default -> {
                     System.err.println("Unknown option: '" + opt + "'.");
                     System.exit(64);

--- a/lib/src/main/java/com/wjduquette/joe/app/ReplTool.java
+++ b/lib/src/main/java/com/wjduquette/joe/app/ReplTool.java
@@ -35,11 +35,12 @@ public class ReplTool implements Tool {
             > 1 + 1;
             -> 2
             >
-            
+        
         The options are as follows:
         
-        --bert, -b     Use the experimental "Bert" byte-engine.
-        --debug, -d    Enable debugging output.  This is mostly of use to
+        --bert,   -b   Use the "Bert" byte-engine (default).
+        --walker, -w   Use the "Walker" AST-walker engine.
+        --debug,  -d   Enable debugging output.  This is mostly of use to
                        the Joe maintainer.
         """,
         ReplTool::main
@@ -72,13 +73,14 @@ public class ReplTool implements Tool {
 
     private void run(String[] args) {
         var argq = new ArrayDeque<>(List.of(args));
-        var engineType = Joe.WALKER;
+        var engineType = Joe.BERT;
         var debug = false;
 
         while (!argq.isEmpty() && argq.peek().startsWith("-")) {
             var opt = argq.poll();
             switch (opt) {
                 case "--bert", "-b" -> engineType = Joe.BERT;
+                case "--walker", "-w" -> engineType = Joe.WALKER;
                 case "--debug", "-d" -> debug = true;
                 default -> {
                     System.err.println("Unknown option: '" + opt + "'.");
@@ -98,6 +100,8 @@ public class ReplTool implements Tool {
         }
 
         try {
+            System.out.println("Joe " + App.getVersion() + " (" +
+                joe.engineName() + " engine)");
             runPrompt();
         } catch (IOException ex) {
             System.err.print(

--- a/lib/src/main/java/com/wjduquette/joe/app/RunTool.java
+++ b/lib/src/main/java/com/wjduquette/joe/app/RunTool.java
@@ -25,8 +25,9 @@ public class RunTool implements Tool {
         """
         Executes the script.  The options are as follows:
         
-        --bert, -b     Use the experimental "Bert" byte-engine.
-        --debug, -d    Enable debugging output.  This is mostly of use to
+        --bert,   -b   Use the "Bert" byte-engine (default).
+        --walker, -w   Use the "Walker" AST-walker engine.
+        --debug,  -d   Enable debugging output.  This is mostly of use to
                        the Joe maintainer.
         """,
         RunTool::main
@@ -59,13 +60,14 @@ public class RunTool implements Tool {
             System.exit(64);
         }
 
-        var engineType = Joe.WALKER;
+        var engineType = Joe.BERT;
         var debug = false;
 
         while (!argq.isEmpty() && argq.peek().startsWith("-")) {
             var opt = argq.poll();
             switch (opt) {
                 case "--bert", "-b" -> engineType = Joe.BERT;
+                case "--walker", "-w" -> engineType = Joe.WALKER;
                 case "--debug", "-d" -> debug = true;
                 default -> {
                     System.err.println("Unknown option: '" + opt + "'.");
@@ -86,6 +88,10 @@ public class RunTool implements Tool {
         }
 
         try {
+            if (debug) {
+                System.out.println("Joe " + App.getVersion() + " (" +
+                    joe.engineName() + " engine)");
+            }
             joe.runFile(path);
         } catch (IOException ex) {
             System.err.println("Could not read script: " + path +

--- a/lib/src/main/java/com/wjduquette/joe/app/RunTool.java
+++ b/lib/src/main/java/com/wjduquette/joe/app/RunTool.java
@@ -8,6 +8,8 @@ import com.wjduquette.joe.tools.Tool;
 import com.wjduquette.joe.tools.ToolInfo;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.List;
 
@@ -62,12 +64,14 @@ public class RunTool implements Tool {
 
         var engineType = Joe.BERT;
         var debug = false;
+        var measureRuntime = false;
 
         while (!argq.isEmpty() && argq.peek().startsWith("-")) {
             var opt = argq.poll();
             switch (opt) {
                 case "--bert", "-b" -> engineType = Joe.BERT;
                 case "--walker", "-w" -> engineType = Joe.WALKER;
+                case "--time", "-t" -> measureRuntime = true;
                 case "--debug", "-d" -> debug = true;
                 default -> {
                     System.err.println("Unknown option: '" + opt + "'.");
@@ -92,7 +96,14 @@ public class RunTool implements Tool {
                 System.out.println("Joe " + App.getVersion() + " (" +
                     joe.engineName() + " engine)");
             }
+            var startTime = Instant.now();
             joe.runFile(path);
+            var endTime = Instant.now();
+
+            if (measureRuntime) {
+                var duration = Duration.between(startTime, endTime).toMillis() / 1000.0;
+                System.out.printf("Run-time: %.3f seconds\n", duration);
+            }
         } catch (IOException ex) {
             System.err.println("Could not read script: " + path +
                 "\n*** " + ex.getMessage());

--- a/lib/src/main/java/com/wjduquette/joe/app/VersionTool.java
+++ b/lib/src/main/java/com/wjduquette/joe/app/VersionTool.java
@@ -5,8 +5,6 @@ import com.wjduquette.joe.tools.ToolInfo;
 
 import java.util.ArrayDeque;
 import java.util.List;
-import java.util.jar.Attributes;
-import java.util.jar.Manifest;
 
 /**
  * The implementation for the {@code joe version} tool.
@@ -52,8 +50,8 @@ public class VersionTool implements Tool {
             System.exit(64);
         }
 
-        try {
-            var attrs = getManifestAttributes();
+        var attrs = App.getManifestAttributes();
+        if (attrs != null) {
             var version = attrs.getValue("Implementation-Version");
             var date = attrs.getValue("Built-Date");
 
@@ -62,14 +60,8 @@ public class VersionTool implements Tool {
             } else {
                 println("Joe (dev build)");
             }
-        } catch (Exception ex) {
-            println("Failed to read Joe manifest: " + ex.getMessage());
-        }
-    }
-
-    private Attributes getManifestAttributes() throws Exception {
-        try (var stream = getClass().getResourceAsStream("/META-INF/MANIFEST.MF")) {
-            return new Manifest(stream).getMainAttributes();
+        } else {
+            println("Joe (dev build)");
         }
     }
 

--- a/lib/src/main/java/com/wjduquette/joe/tools/test/TestTool.java
+++ b/lib/src/main/java/com/wjduquette/joe/tools/test/TestTool.java
@@ -28,9 +28,11 @@ public class TestTool implements Tool {
         Options:
         
         --bert, -b
-           Use the experimental "Bert" byte-engine.  A minimum of features
-           are available.
-           
+            Use the "Bert" byte-engine (the default).
+        
+        --walker, -w
+            Use the "Walker" AST-walker engine.
+        
         --verbose, -v
             Enable verbose output.  Normally only failures and the final
             summary are included in the output.  If this is given, all test
@@ -50,7 +52,7 @@ public class TestTool implements Tool {
     //-------------------------------------------------------------------------
     // Instance Variables
 
-    String engineType = Joe.WALKER;
+    String engineType = Joe.BERT;
     boolean verbose = false;
     private final List<String> testScripts = new ArrayList<>();
     private int loadErrorCount = 0;
@@ -90,12 +92,15 @@ public class TestTool implements Tool {
 
             switch (arg) {
                 case "--bert", "-b" -> engineType = Joe.BERT;
+                case "--walker", "-w" -> engineType = Joe.WALKER;
                 case "-v", "--verbose" -> verbose = true;
                 default -> testScripts.add(arg);
             }
         }
 
         // NEXT, run the tests.
+        System.out.println("Joe " + App.getVersion() + " (" +
+            engineType + " engine)");
         for (var path : testScripts) {
             runTest(path);
         }

--- a/lib/src/main/java/com/wjduquette/joe/tools/test/TestTool.java
+++ b/lib/src/main/java/com/wjduquette/joe/tools/test/TestTool.java
@@ -6,6 +6,8 @@ import com.wjduquette.joe.tools.Tool;
 import com.wjduquette.joe.tools.ToolInfo;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
@@ -99,11 +101,16 @@ public class TestTool implements Tool {
         }
 
         // NEXT, run the tests.
+        var startTime = Instant.now();
         System.out.println("Joe " + App.getVersion() + " (" +
             engineType + " engine)");
         for (var path : testScripts) {
             runTest(path);
         }
+        var endTime = Instant.now();
+        var duration = Duration.between(startTime, endTime).toMillis() / 1000.0;
+
+        System.out.printf("Run-time: %.3f seconds\n", duration);
 
         // NEXT, print the final results
         var total = successCount + skipCount + failureCount + errorCount;

--- a/lib/src/main/java/com/wjduquette/joe/tools/win/WinTool.java
+++ b/lib/src/main/java/com/wjduquette/joe/tools/win/WinTool.java
@@ -24,6 +24,13 @@ public class WinTool extends FXTool {
         Given a script, this tool displays a JavaFX GUI.  The tool provides
         the Joe standard library along with the optional joe.console and
         joe.win packages.  See the Joe User's Guide for details.
+        
+        Executes the script.  The options are as follows:
+        
+        --bert,   -b   Use the "Bert" byte-engine (default).
+        --walker, -w   Use the "Walker" AST-walker engine.
+        --debug,  -d   Enable debugging output.  This is mostly of use to
+                       the Joe maintainer.
         """,
         WinTool::main
     );
@@ -31,7 +38,8 @@ public class WinTool extends FXTool {
     //------------------------------------------------------------------------
     // Instance Variables
 
-    private final Joe joe = new Joe();
+    // Keeps joe from being collected.
+    private Joe joe;
     private final VBox root = new VBox();
 
     //------------------------------------------------------------------------
@@ -50,6 +58,31 @@ public class WinTool extends FXTool {
         if (args.isEmpty()) {
             printUsage(App.NAME);
             exit(64);
+        }
+
+        // NEXT, parse the options.
+        var engineType = Joe.BERT;
+        var debug = false;
+
+        while (!args.isEmpty() && args.peek().startsWith("-")) {
+            var opt = args.poll();
+            switch (opt) {
+                case "--bert", "-b" -> engineType = Joe.BERT;
+                case "--walker", "-w" -> engineType = Joe.WALKER;
+                case "--debug", "-d" -> debug = true;
+                default -> {
+                    System.err.println("Unknown option: '" + opt + "'.");
+                    System.exit(64);
+                }
+            }
+        }
+
+        var joe = new Joe(engineType);
+        joe.setDebug(debug);
+
+        if (debug) {
+            System.out.println("Joe " + App.getVersion() + " (" +
+                joe.engineName() + " engine)");
         }
 
         // NEXT, create the scene with default settings.


### PR DESCRIPTION
This pull-request revised Joe and the various `joe` tools to use 
the Bert byte-engine by default instead of the older Walker AST-walker engine.

Every `joe` tool used to process scripts now has a `-w`/`--walker` option to select the
old engine, and outputs the Joe version number and engine name when and if appropriate.

In addition, `joe test` outputs timing information and `joe run` does so if given the `-t`
option.