### PR TITLE
`TypedValue` simplification

### DIFF
--- a/lib/src/main/java/com/wjduquette/joe/NullValue.java
+++ b/lib/src/main/java/com/wjduquette/joe/NullValue.java
@@ -1,0 +1,52 @@
+package com.wjduquette.joe;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * A `JoeValue` for `null`.
+ */
+class NullValue implements JoeValue {
+    @Override
+    public JoeType type() {
+        return null;
+    }
+
+    @Override
+    public String typeName() {
+        return "null";
+    }
+
+    @Override
+    public boolean hasField(String name) {
+        return false;
+    }
+
+    @Override
+    public List<String> getFieldNames() {
+        return List.of();
+    }
+
+    @Override
+    public Object get(String name) {
+        throw new JoeError("`null` has no properties.");
+    }
+
+    @Override
+    public void set(String name, Object value) {
+        throw new JoeError("`null` has no properties.");
+    }
+
+    @Override
+    public Collection<?> getItems() {
+        throw new JoeError("`null` is not iterable.");
+    }
+
+    @Override public String stringify(Joe joe) {
+        return "null";
+    }
+
+    @Override public String toString() {
+        return "null";
+    }
+}

--- a/lib/src/main/java/com/wjduquette/joe/ProxyType.java
+++ b/lib/src/main/java/com/wjduquette/joe/ProxyType.java
@@ -197,13 +197,80 @@ public class ProxyType<V>
 
     /**
      * Returns a stringified value, i.e., a value for display.
-     * Defaults to the value's toString().
+     * Defaults to the value's toString().  Subclasses may override.
      * @param joe The engine
-     * @param value The value
+     * @param value A value of the proxied type
      * @return The string
      */
     public String stringify(Joe joe, Object value) {
         return value.toString();
+    }
+
+    /**
+     * Returns true if the value has a field with the given name, and
+     * false otherwise.
+     *
+     * <p>Proxied types are assumed not to have fields, so this always
+     * returns false. Subclasses may override.</p>
+     * @param value A value of the proxied type
+     * @param fieldName The field name
+     * @return true or false
+     */
+    @SuppressWarnings("unused")
+    public boolean hasField(Object value, String fieldName) {
+        return false;
+    }
+
+    /**
+     * Returns a list of the names of the value's fields.  The
+     * list will be empty if the value has no fields.
+     *
+     * <p>Proxied types are assumed not to have fields, so this always
+     * returns the empty list. Subclasses may override.</p>
+     * @param value A value of the proxied type
+     * @return The list
+     */
+    @SuppressWarnings("unused")
+    public List<String> getFieldNames(Object value) {
+        return List.of();
+    }
+
+    /**
+     * Gets the value of the named property.  Throws an
+     * "Undefined property" error if there is no such property.
+     *
+     * <p>Proxied types are assumed not to have fields, so this only
+     * looks for method properties. Subclasses may override.</p>
+     * @param value A value of the proxied type
+     * @param propertyName The property name
+     * @return The property value
+     */
+    @SuppressWarnings("unused")
+    public Object get(Object value, String propertyName) {
+        var method = bind(value, propertyName);
+
+        if (method != null) {
+            return method;
+        } else {
+            throw new JoeError("Undefined property '" +
+                propertyName + "'.");
+        }
+    }
+
+    /**
+     * Sets the value of the named field.
+     *
+     * <p>Proxied types are assumed not to have fields, so this always
+     * throws a JoeError. Subclasses may override.</p>
+     * @param value A value of the proxied type
+     * @param fieldName The field name
+     * @param other The value to
+     * @return The property value
+     */
+    @SuppressWarnings("unused")
+    public Object set(Object value, String fieldName, Object other) {
+        throw new JoeError("Values of type " + name +
+            " have no field properties.");
     }
 
     //-------------------------------------------------------------------------

--- a/lib/src/main/java/com/wjduquette/joe/TypedValue.java
+++ b/lib/src/main/java/com/wjduquette/joe/TypedValue.java
@@ -21,9 +21,7 @@ record TypedValue(Joe joe, ProxyType<?> proxy, Object value)
 
     @Override
     public String typeName() {
-        return proxy != null
-            ? proxy.name()
-            : value.getClass().getName();
+        return proxy.name();
     }
 
     @Override
@@ -72,11 +70,7 @@ record TypedValue(Joe joe, ProxyType<?> proxy, Object value)
     }
 
     @Override public String stringify(Joe joe) {
-        if (proxy != null) {
-            return proxy.stringify(joe, value);
-        } else {
-            return value.toString();
-        }
+        return proxy.stringify(joe, value);
     }
 
     @Override public String toString() {

--- a/lib/src/main/java/com/wjduquette/joe/TypedValue.java
+++ b/lib/src/main/java/com/wjduquette/joe/TypedValue.java
@@ -26,37 +26,22 @@ record TypedValue(Joe joe, ProxyType<?> proxy, Object value)
 
     @Override
     public boolean hasField(String name) {
-        // The value is of a proxied type, and so has
-        // method properties but not field properties.
-        return false;
+        return proxy.hasField(value, name);
     }
 
     @Override
     public List<String> getFieldNames() {
-        // The value is of a proxied type, and so has
-        // method properties but not field properties.
-        return List.of();
+        return proxy.getFieldNames(value);
     }
 
     @Override
     public Object get(String name) {
-        // The value is of a proxied type, and so has
-        // method properties but not field properties.
-        var method = proxy.bind(value, name);
-        if (method != null) {
-            return method;
-        } else {
-            throw new JoeError("Undefined property '" + name + "'.");
-        }
+        return proxy.get(value, name);
     }
 
     @Override
-    public void set(String name, Object value) {
-        // The value is either of an opaque type or a proxied native type.
-        // Neither kind of type has field properties.
-        throw new JoeError("Values of type " +
-            value.getClass().getName() +
-            " have no field properties.");
+    public void set(String name, Object other) {
+        proxy.set(value, name, other);
     }
 
     @Override

--- a/lib/src/main/java/com/wjduquette/joe/bert/VirtualMachine.java
+++ b/lib/src/main/java/com/wjduquette/joe/bert/VirtualMachine.java
@@ -623,7 +623,7 @@ class VirtualMachine {
 
                     // Note: this works for all JoeObjects, including
                     // `BertClass` and `BertInstance`.
-                    var joeObject = joe.getJoeObject(target);
+                    var joeObject = joe.getJoeValue(target);
                     pop();
                     push(joeObject.get(name));
                 }
@@ -636,7 +636,7 @@ class VirtualMachine {
                     }
 
                     // Handle JoeObjects
-                    var joeObject = joe.getJoeObject(target);
+                    var joeObject = joe.getJoeValue(target);
                     var value = pop();
                     joeObject.set(name, value);
                     pop();       // Pop the instance
@@ -799,7 +799,7 @@ class VirtualMachine {
             case Collection<?> c -> c;
             case JoeIterable i -> i.getItems();
             default -> {
-                var instance = joe.getJoeObject(arg);
+                var instance = joe.getJoeValue(arg);
                 if (instance.canIterate()) {
                     yield instance.getItems();
                 } else {

--- a/lib/src/main/java/com/wjduquette/joe/types/JoeSingleton.java
+++ b/lib/src/main/java/com/wjduquette/joe/types/JoeSingleton.java
@@ -77,7 +77,7 @@ public class JoeSingleton extends ProxyType<Void> {
     // fields.
     private Object _getFieldNames(Joe joe, Args args) {
         args.exactArity(1, "getFieldNames(value)");
-        var value = joe.getJoeObject(args.next());
+        var value = joe.getJoeValue(args.next());
         return joe.readonlyList(value.getFieldNames());
     }
 
@@ -90,7 +90,7 @@ public class JoeSingleton extends ProxyType<Void> {
     // defined Joe binding.
     private Object _isOpaque(Joe joe, Args args) {
         args.exactArity(1, "isOpaque(value)");
-        var obj = joe.getJoeObject(args.next());
+        var obj = joe.getJoeValue(args.next());
         return obj.type() instanceof OpaqueType;
     }
 
@@ -140,6 +140,6 @@ public class JoeSingleton extends ProxyType<Void> {
     // Returns the Joe type of the given *value*.
     private Object _typeOf(Joe joe, Args args) {
         args.exactArity(1, "typeOf(value)");
-        return joe.getJoeObject(args.next()).type();
+        return joe.getJoeValue(args.next()).type();
     }
 }

--- a/lib/src/main/java/com/wjduquette/joe/walker/Interpreter.java
+++ b/lib/src/main/java/com/wjduquette/joe/walker/Interpreter.java
@@ -436,7 +436,7 @@ class Interpreter {
                         "Tried to retrieve '" + expr.name().lexeme() +
                         "' property from null value.");
                 }
-                JoeValue instance = joe.getJoeObject(object);
+                JoeValue instance = joe.getJoeValue(object);
                 yield instance.get(expr.name().lexeme());
             }
             // (expr...)
@@ -579,7 +579,7 @@ class Interpreter {
             // ++ and -- with an object property
             case Expr.PrePostSet expr -> {
                 Object object = evaluate(expr.object());
-                JoeValue instance = joe.getJoeObject(object);
+                JoeValue instance = joe.getJoeValue(object);
                 var name = expr.name().lexeme();
                 var prior = instance.get(name);
                 checkNumericTarget(expr.op(), prior);
@@ -595,7 +595,7 @@ class Interpreter {
             // Assign a value to an object property using =, +=, -=, *=, /=
             case Expr.Set expr -> {
                 Object object = evaluate(expr.object());
-                JoeValue instance = joe.getJoeObject(object);
+                JoeValue instance = joe.getJoeValue(object);
 
                 Object right = evaluate(expr.value());
                 var name = expr.name().lexeme();
@@ -709,7 +709,7 @@ class Interpreter {
             case Collection<?> c -> c;
             case JoeIterable i -> i.getItems();
             default -> {
-                var instance = joe.getJoeObject(arg);
+                var instance = joe.getJoeValue(arg);
                 if (instance.canIterate()) {
                     yield instance.getItems();
                 } else {


### PR DESCRIPTION
The `TypedValue` class works with a `ProxyType` to convert a native Java value to a `JoeValue`.  `TypedValue` has some policy code that more properly belongs in `ProxyType`.  This pull request adds a new API to `ProxyType` for the use of `TypedValue`, which has two effects:

- Concrete `ProxyTypes` can implement different policies, e.g., regarding field access.
- `ProxyType` is now contains no policy code, and won't need to be changed unless we change the `JoeValue` interface.