### PR TITLE
`if let` and `match` bugs

### DIFF
--- a/lib/src/main/java/com/wjduquette/joe/walker/Interpreter.java
+++ b/lib/src/main/java/com/wjduquette/joe/walker/Interpreter.java
@@ -245,25 +245,25 @@ class Interpreter {
                     if (c.pattern() == null) return execute(c.statement());
 
                     // case pattern ->
-                    var constants = new ArrayList<>();
-                    c.pattern().getConstants().forEach(e ->
-                        constants.add(evaluate(e)));
-                    var values = new ArrayList<>();
-                    if (Matcher.bind(
-                        joe,
-                        c.pattern().getPattern(),
-                        target,
-                        constants::get,
-                        values::add
-                    )) {
-                        var previous = this.environment;
-                        try {
-                            this.environment = new Environment(previous);
+                    var previous = this.environment;
+                    try {
+                        this.environment = new Environment(previous);
+                        var constants = new ArrayList<>();
+                        c.pattern().getConstants().forEach(e ->
+                            constants.add(evaluate(e)));
+                        var values = new ArrayList<>();
+                        if (Matcher.bind(
+                            joe,
+                            c.pattern().getPattern(),
+                            target,
+                            constants::get,
+                            values::add
+                        )) {
                             bind(c.pattern(), values);
                             return execute(c.statement());
-                        } finally {
-                            this.environment = previous;
                         }
+                    } finally {
+                        this.environment = previous;
                     }
                 }
             }

--- a/lib/src/main/java/com/wjduquette/joe/walker/Interpreter.java
+++ b/lib/src/main/java/com/wjduquette/joe/walker/Interpreter.java
@@ -193,27 +193,29 @@ class Interpreter {
                 }
             }
             case Stmt.IfLet stmt -> {
-                var constants = new ArrayList<>();
-                stmt.pattern().getConstants().forEach(e ->
-                    constants.add(evaluate(e)));
-                var target = evaluate(stmt.target());
-                var values = new ArrayList<>();
-                if (Matcher.bind(
-                    joe,
-                    stmt.pattern().getPattern(),
-                    target,
-                    constants::get,
-                    values::add
-                )) {
-                    var previous = this.environment;
-                    try {
-                        this.environment = new Environment(previous);
+                var previous = this.environment;
+                this.environment = new Environment(previous);
+                try {
+                    var constants = new ArrayList<>();
+                    stmt.pattern().getConstants().forEach(e ->
+                        constants.add(evaluate(e)));
+                    var target = evaluate(stmt.target());
+                    var values = new ArrayList<>();
+                    if (Matcher.bind(
+                        joe,
+                        stmt.pattern().getPattern(),
+                        target,
+                        constants::get,
+                        values::add
+                    )) {
                         bind(stmt.pattern(), values);
                         return execute(stmt.thenBranch());
-                    } finally {
-                        this.environment = previous;
                     }
-                } else if (stmt.elseBranch() != null) {
+                } finally {
+                    this.environment = previous;
+                }
+
+                if (stmt.elseBranch() != null) {
                     return execute(stmt.elseBranch());
                 }
             }

--- a/tests/lang_if_let.joe
+++ b/tests/lang_if_let.joe
@@ -33,6 +33,35 @@ function testElseClause() {
     assertTrue(noMatch);
 }
 
+// Verify that we can read the target from a variable.
+// (based on a real bug)
+function testVarTarget() {
+    var list = [#a, "match"];
+    var result;
+    if let ([#a, x] = list) {
+        result = x;
+        assertEquals(list, [#a, "match"]);
+    } else {
+        result = "no match";
+    }
+    assertEquals(result, "match");
+}
+
+// Verify that we can read constants from interpolated variables.
+function testInterpolated() {
+    var tag = #a;
+    var list = [tag, "match"];
+    var result;
+    if let ([$tag, x] = list) {
+        result = x;
+        assertEquals(list, [#a, "match"]);
+    } else {
+        result = "no match";
+    }
+    assertEquals(result, "match");
+}
+
+
 // Verify that pattern variables do not modify shadowed variables on match.
 function testShadowedVar_match() {
     var a = "outer";

--- a/tests/lang_match.joe
+++ b/tests/lang_match.joe
@@ -86,6 +86,31 @@ function testMatch_finalWildcard() {
     assertEquals(result, #ok);
 }
 
+function testVarTarget() {
+    var map = {#b: 2};
+    var result;
+
+    match (map) {
+        case {#a: a} -> { result = a; }
+        case {#b: b} -> { result = b; }
+        default -> { result = "no match"; }
+    }
+    assertEquals(result, 2);
+}
+
+function testInterpolatedConstant() {
+    var tag = #b;
+    var map = {tag: 2};
+    var result;
+
+    match (map) {
+        case {#a: a} -> { result = a; }
+        case {$tag: b} -> { result = b; }
+        default -> { result = "no match"; }
+    }
+    assertEquals(result, 2);
+}
+
 // Verify that a function can close over pattern variables.
 function testMatch_WithClosures() {
     function getFunc(map) {


### PR DESCRIPTION
Both the `if let` and `match` statements had variable resolution errors in the Walker engine:

- The `Resolver` defined a new scope *before* resolving the match target and the pattern constants (as it should).
- The `Interpreter` created the matching `Environment` *after* evaluating the match target and the pattern constants.

Fixed, and added relevant tests to `lang_if_let.joe` and `lang_match.joe`.