### PR TITLE
Nero constraints

### DIFF
--- a/lib/src/main/java/com/wjduquette/joe/nero/Constraint.java
+++ b/lib/src/main/java/com/wjduquette/joe/nero/Constraint.java
@@ -1,0 +1,7 @@
+package com.wjduquette.joe.nero;
+
+public record Constraint(Term.Variable a, Op op, Term b) {
+    @Override public String toString() {
+        return a + " " + op.lexeme() + " " + b;
+    }
+}

--- a/lib/src/main/java/com/wjduquette/joe/nero/Nero.java
+++ b/lib/src/main/java/com/wjduquette/joe/nero/Nero.java
@@ -58,15 +58,9 @@ public class Nero {
             }
         }
 
-        System.out.println("Stratification:");
-
-        var graph = new Graph(rules);
-        if (!graph.isStratified()) {
-            throw new JoeError("Rule set is unstratified.");
-        }
-        System.out.println("  Strata: " + graph.strata());
-
+        // Will throw JoeError if the rules aren't stratified.
         var ruleset = new RuleSet(rules, baseFacts);
+
         // Could add more facts here, in theory.
 
         try {

--- a/lib/src/main/java/com/wjduquette/joe/nero/Op.java
+++ b/lib/src/main/java/com/wjduquette/joe/nero/Op.java
@@ -1,0 +1,19 @@
+package com.wjduquette.joe.nero;
+
+/**
+ * A comparison operator, as used in constraints.
+ */
+public enum Op {
+    EQ("=="),
+    NE("!="),
+    GT(">"),
+    GE(">="),
+    LT("<"),
+    LE("<=");
+
+    private final String lexeme;
+
+    Op(String lexeme) { this.lexeme = lexeme; }
+    public String lexeme() { return lexeme; }
+}
+

--- a/lib/src/main/java/com/wjduquette/joe/nero/Rule.java
+++ b/lib/src/main/java/com/wjduquette/joe/nero/Rule.java
@@ -11,12 +11,20 @@ import java.util.stream.Collectors;
  * @param head The rule's head
  * @param body The body predicates
  */
-public record Rule(Atom head, List<Atom> body) {
+public record Rule(
+    Atom head,
+    List<Atom> body,
+    List<Constraint> constraints
+) {
     @Override
     public String toString() {
         var bodyString = body.stream().map(Atom::toString)
             .collect(Collectors.joining(", "));
-        return head + " :- " + bodyString + ".";
+        var constraintString = constraints.stream().map(Constraint::toString)
+            .collect(Collectors.joining(", "));
+        return head + " :- " + bodyString
+            + (constraints.isEmpty() ? "" : " where " + constraintString)
+            + ".";
     }
 
     @Override
@@ -24,13 +32,16 @@ public record Rule(Atom head, List<Atom> body) {
         if (o == null || getClass() != o.getClass()) return false;
 
         Rule rule = (Rule) o;
-        return head.equals(rule.head) && body.equals(rule.body);
+        return head.equals(rule.head)
+            && body.equals(rule.body)
+            && constraints.equals(rule.constraints);
     }
 
     @Override
     public int hashCode() {
         int result = head.hashCode();
         result = 31 * result + body.hashCode();
+        result = 31 * result + constraints.hashCode();
         return result;
     }
 }

--- a/lib/src/main/java/com/wjduquette/joe/nero/RuleSet.java
+++ b/lib/src/main/java/com/wjduquette/joe/nero/RuleSet.java
@@ -164,6 +164,13 @@ public class RuleSet {
             }
         }
 
+        // NEXT, check the bindings against the constraints.
+        for (var c : rule.constraints()) {
+            if (!constraintMet(c, bindings)) {
+                return null;
+            }
+        }
+
         // NEXT, build the list of terms and return the new fact.
         var terms = new ArrayList<>();
 
@@ -175,6 +182,59 @@ public class RuleSet {
         }
 
         return new Fact(rule.head().relation(), terms);
+    }
+
+    private boolean constraintMet(
+        Constraint constraint,
+        Map<Variable,Object> bindings
+    ) {
+        var a = bindings.get(constraint.a());
+
+        var b = switch (constraint.b()) {
+            case Variable v -> bindings.get(v);
+            case Constant c -> c.value();
+        };
+
+        return switch (constraint.op()) {
+            case EQ -> Objects.equals(a, b);
+            case NE -> !Objects.equals(a, b);
+            case GT -> {
+                if (a instanceof Double d1 && b instanceof Double d2) {
+                    yield d1 > d2;
+                } else if (a instanceof String s1 && b instanceof String s2) {
+                    yield s1.compareTo(s2) > 0;
+                } else {
+                    yield false;
+                }
+            }
+            case GE -> {
+                if (a instanceof Double d1 && b instanceof Double d2) {
+                    yield d1 >= d2;
+                } else if (a instanceof String s1 && b instanceof String s2) {
+                    yield s1.compareTo(s2) >= 0;
+                } else {
+                    yield false;
+                }
+            }
+            case LT -> {
+                if (a instanceof Double d1 && b instanceof Double d2) {
+                    yield d1 < d2;
+                } else if (a instanceof String s1 && b instanceof String s2) {
+                    yield s1.compareTo(s2) < 0;
+                } else {
+                    yield false;
+                }
+            }
+            case LE -> {
+                if (a instanceof Double d1 && b instanceof Double d2) {
+                    yield d1 <= d2;
+                } else if (a instanceof String s1 && b instanceof String s2) {
+                    yield s1.compareTo(s2) <= 0;
+                } else {
+                    yield false;
+                }
+            }
+        };
     }
 
     // Return a copy of the atom replacing variables with bound

--- a/lib/src/main/java/com/wjduquette/joe/nero/RuleSet.java
+++ b/lib/src/main/java/com/wjduquette/joe/nero/RuleSet.java
@@ -44,6 +44,7 @@ public class RuleSet {
         }
 
         this.strata = graph.strata();
+        System.out.println("  Strata: " + strata);
 
         // NEXT, Categorize the rules by head relation
         for (var rule : rules) {

--- a/lib/src/main/java/com/wjduquette/joe/nero/Scanner.java
+++ b/lib/src/main/java/com/wjduquette/joe/nero/Scanner.java
@@ -17,6 +17,7 @@ class Scanner {
     static {
         reserved = new HashMap<>();
         reserved("not",   NOT);
+        reserved("where", WHERE);
     }
 
     private static void reserved(String word, TokenType token) {
@@ -77,13 +78,26 @@ class Scanner {
     private void scanToken() {
         char c = advance();
         switch (c) {
+            // One-character tokens
             case '('  -> addToken(LEFT_PAREN);
             case ')'  -> addToken(RIGHT_PAREN);
             case ','  -> addToken(COMMA);
             case '.'  -> addToken(DOT);
+
+            // One-or-two-character tokens
+            case '!' -> {
+                if (match('=')) addToken(BANG_EQUAL);
+            }
             case ':'  -> {
                 if (match('-')) addToken(COLON_MINUS);
             }
+            case '=' -> {
+                if (match('=')) addToken(EQUAL_EQUAL);
+            }
+            case '>' -> addToken(match('=') ? GREATER_EQUAL : GREATER);
+            case '<' -> addToken(match('=') ? LESS_EQUAL : LESS);
+
+            // Comments and whitespace
             case '/'  -> {
                 if (match('/')) {
                     // A comment goes until the end of the line.
@@ -93,6 +107,8 @@ class Scanner {
             case ' ', '\r', '\t', '\n' -> {
                 // Ignore whitespace.
             }
+
+            // Literals, identifiers, and reserved words
             case '"' -> string();
             case '#' -> keyword();
             default -> {

--- a/lib/src/main/java/com/wjduquette/joe/nero/TokenType.java
+++ b/lib/src/main/java/com/wjduquette/joe/nero/TokenType.java
@@ -7,13 +7,17 @@ enum TokenType {
     COMMA, DOT,
 
     // One or two character tokens.
+    BANG_EQUAL,
     COLON_MINUS,
+    EQUAL_EQUAL,
+    GREATER, GREATER_EQUAL,
+    LESS, LESS_EQUAL,
 
     // Literals.
     IDENTIFIER, STRING, NUMBER, KEYWORD,
 
     // Reserved Words.
-    NOT,
+    NOT, WHERE,
 
     EOF
 }

--- a/nero/constraints.nero
+++ b/nero/constraints.nero
@@ -1,0 +1,6 @@
+// Constraints
+
+Node(#a).
+Node(#b).
+Pair(x, y) :- Node(x), Node(y) where x != y.
+

--- a/nero/constraints.nero
+++ b/nero/constraints.nero
@@ -4,3 +4,11 @@ Node(#a).
 Node(#b).
 Pair(x, y) :- Node(x), Node(y) where x != y.
 
+//    ID,       Size
+Thing(#pen,     1).
+Thing(#desk,    10).
+Thing(#whatsit, #unknown).
+
+// #whatsit is neither large nor small
+Small(x) :- Thing(x, size) where size < 5.
+Large(x) :- Thing(x, size) where size > 5.


### PR DESCRIPTION
This pull request adds an optional `where` clause to Nero rules, containing one or more constraints of the form `x OP y`. 