### PR TITLE
Scanner Priming Error

### DIFF
--- a/lib/src/main/java/com/wjduquette/joe/bert/Compiler.java
+++ b/lib/src/main/java/com/wjduquette/joe/bert/Compiler.java
@@ -124,6 +124,7 @@ class Compiler {
         parser.hadError = false;
         parser.panicMode = false;
         scanner = new Scanner(buffer, this::errorInScanner);
+        scanner.advance(); // Prime the scanner
 
         while (!scanner.match(EOF)) {
             declaration();

--- a/lib/src/main/java/com/wjduquette/joe/bert/Compiler.java
+++ b/lib/src/main/java/com/wjduquette/joe/bert/Compiler.java
@@ -1,12 +1,12 @@
 package com.wjduquette.joe.bert;
 
 import com.wjduquette.joe.Joe;
-import com.wjduquette.joe.scanner.SourceBuffer;
-import com.wjduquette.joe.scanner.SourceBuffer.Span;
 import com.wjduquette.joe.SyntaxError;
 import com.wjduquette.joe.Trace;
 import com.wjduquette.joe.patterns.Pattern;
 import com.wjduquette.joe.scanner.Scanner;
+import com.wjduquette.joe.scanner.SourceBuffer;
+import com.wjduquette.joe.scanner.SourceBuffer.Span;
 import com.wjduquette.joe.scanner.Token;
 import com.wjduquette.joe.scanner.TokenType;
 

--- a/lib/src/main/java/com/wjduquette/joe/clark/Compiler.java
+++ b/lib/src/main/java/com/wjduquette/joe/clark/Compiler.java
@@ -124,6 +124,7 @@ class Compiler {
         parser.hadError = false;
         parser.panicMode = false;
         scanner = new Scanner(buffer, this::errorInScanner);
+        scanner.advance();  // Prime the scanner
 
         while (!scanner.match(EOF)) {
             declaration();

--- a/lib/src/main/java/com/wjduquette/joe/clark/Compiler.java
+++ b/lib/src/main/java/com/wjduquette/joe/clark/Compiler.java
@@ -10,9 +10,9 @@ import com.wjduquette.joe.scanner.SourceBuffer.Span;
 import com.wjduquette.joe.scanner.Token;
 import com.wjduquette.joe.scanner.TokenType;
 
-import java.util.*;
-
 import static com.wjduquette.joe.scanner.TokenType.*;
+
+import java.util.*;
 
 /**
  * The Bert byte-compiler.  This is a single-pass compiler, parsing the

--- a/lib/src/main/java/com/wjduquette/joe/scanner/Scanner.java
+++ b/lib/src/main/java/com/wjduquette/joe/scanner/Scanner.java
@@ -36,15 +36,16 @@ public class Scanner {
 
     /**
      * Creates a scanner on the given source buffer.
-     * On creation, previous() will return null and peek() will return the
-     * next token.  The error handler might be called on creation.
+     *
+     * <p>The scanner must be primed before use by calling advance() a
+     * single time.  This will scan the first token...and possibly
+     * call the error handler.</p>
      * @param buffer The source text
      * @param errorHandler The handler for scan errors.
      */
     public Scanner(SourceBuffer buffer, ErrorHandler errorHandler) {
         this.errorHandler = errorHandler;
         this.tokenizer = new Tokenizer(buffer);
-        advance();
     }
 
     //-------------------------------------------------------------------------

--- a/lib/src/main/java/com/wjduquette/joe/scanner/Scanner.java
+++ b/lib/src/main/java/com/wjduquette/joe/scanner/Scanner.java
@@ -122,18 +122,21 @@ public class Scanner {
      * Advances the scanner by one token, reporting any errors.
      */
     public void advance() {
+        Token error =  null;
+
         // FIRST, slide the window.
         previous = current;
 
         // NEXT, get the next non-error token.
         for (;;) {
             current = tokenizer.scanToken();
-            if (current.type() == ERROR) {
-                // Report the error.
-                errorHandler.handle(current.span(), (String)current.literal());
-            } else {
-                break;
-            }
+            if (current.type() != ERROR) break;
+            if (error == null) error = current;
+        }
+
+        if (error != null) {
+            // Report the error.
+            errorHandler.handle(error.span(), (String)error.literal());
         }
     }
 }


### PR DESCRIPTION
The `joe.scanner.Scanner` uses a sliding window, which needs to be initialized, or "primed", before the client retrieves any tokens.  `Scanner()` attempted to prime the window by calling `advance()`; but this means that `Scanner()` can report a scanning error in the constructor, which causes problems for `joe.parser.Parser`.

This pull request modifies `Scanner` to that clients must prime it explicitly, and modifies the clients to do so safely.