### PR TITLE
`joe.parser.Parser` supports `ASTNamedAtom`.

### DIFF
--- a/lib/src/main/java/com/wjduquette/joe/tools/nero/Compiler.java
+++ b/lib/src/main/java/com/wjduquette/joe/tools/nero/Compiler.java
@@ -101,7 +101,7 @@ public class Compiler {
             );
             case ASTRuleSet.ASTNamedAtom a -> {
                 var terms = new LinkedHashMap<String,Term>();
-                for (var e : a.terms().entrySet()) {
+                for (var e : a.termMap().entrySet()) {
                     terms.put(e.getKey().lexeme(), ast2term(e.getValue()));
                 }
                 yield new NamedAtom(a.relation().lexeme(), terms);

--- a/lib/src/test/java/com/wjduquette/joe/nero/NeroTest.java
+++ b/lib/src/test/java/com/wjduquette/joe/nero/NeroTest.java
@@ -30,6 +30,24 @@ public class NeroTest extends Ted {
     }
 
     @Test
+    public void testSimple_named() {
+        test("testSimple_named");
+        var source = """
+            Parent(#walker, #bert);
+            Parent(#bert, #clark);
+            Ancestor(x, y) :- Parent(f0: x, f1: y);
+            Ancestor(x, y) :- Parent(f0: x, f1: z), Ancestor(f0: z, f1: y);
+            """;
+        check(infer(source)).eq("""
+            Ancestor(#bert, #clark)
+            Ancestor(#walker, #bert)
+            Ancestor(#walker, #clark)
+            Parent(#bert, #clark)
+            Parent(#walker, #bert)
+            """);
+    }
+
+    @Test
     public void testConstraint() {
         test("testConstraint");
         var source = """


### PR DESCRIPTION
The Joe `Parser` will now parse rules containing `ASTNamedAtom` body atoms; and Nero handles them properly.