### PR TITLE
Nero refactoring

### DIFF
--- a/lib/src/main/java/com/wjduquette/joe/JoeNero.java
+++ b/lib/src/main/java/com/wjduquette/joe/JoeNero.java
@@ -2,9 +2,6 @@ package com.wjduquette.joe;
 
 import com.wjduquette.joe.nero.Fact;
 import com.wjduquette.joe.nero.NeroEngine;
-import com.wjduquette.joe.nero.RuleSet;
-import com.wjduquette.joe.nero.RuleSetCompiler;
-import com.wjduquette.joe.parser.Parser;
 import com.wjduquette.joe.types.RuleSetValue;
 import com.wjduquette.joe.types.SetValue;
 
@@ -98,44 +95,5 @@ public class JoeNero {
         }
 
         return result;
-    }
-
-    //-------------------------------------------------------------------------
-    // Static API
-
-    /**
-     * Compiles a Nero script into a RuleSet.
-     * @param script The script
-     * @return The RuleSet
-     * @throws JoeError on any error
-     */
-    public static RuleSet compile(String script) {
-        return new Compiler(script).compile();
-    }
-
-    private static class Compiler {
-        private final String script;
-        private boolean gotParseError = false;
-        private final JoeError error = new JoeError("Error in Nero input.");
-
-        public Compiler(String script) {
-            this.script = script;
-        }
-
-        public RuleSet compile() {
-            var source = new SourceBuffer("*script*", script);
-            var parser = new Parser(source, this::errorHandler);
-            var ast = parser.parseNero();
-            if (gotParseError) {
-                throw error;
-            }
-
-            return new RuleSetCompiler(ast).compile();
-        }
-
-        private void errorHandler(Trace trace, boolean incomplete) {
-            gotParseError = true;
-            error.addFrame(trace.context(), trace.message());
-        }
     }
 }

--- a/lib/src/main/java/com/wjduquette/joe/JoeNero.java
+++ b/lib/src/main/java/com/wjduquette/joe/JoeNero.java
@@ -1,7 +1,7 @@
 package com.wjduquette.joe;
 
 import com.wjduquette.joe.nero.Fact;
-import com.wjduquette.joe.nero.Nero;
+import com.wjduquette.joe.nero.NeroEngine;
 import com.wjduquette.joe.nero.RuleSet;
 import com.wjduquette.joe.nero.RuleSetCompiler;
 import com.wjduquette.joe.parser.Parser;
@@ -14,7 +14,7 @@ import java.util.List;
 
 /**
  * The JoeNero class wraps the
- * {@link com.wjduquette.joe.nero.Nero} Datalog engine, doing the work to
+ * {@link NeroEngine} Datalog engine, doing the work to
  * translate between Joe data and Nero data.
  */
 public class JoeNero {
@@ -78,7 +78,7 @@ public class JoeNero {
         }
 
         // NEXT, Execute the rule set.
-        var nero = new Nero(rsv.ruleset());
+        var nero = new NeroEngine(rsv.ruleset());
         nero.setDebug(rsv.isDebug());
         nero.infer(inputFacts);
 

--- a/lib/src/main/java/com/wjduquette/joe/app/NeroTool.java
+++ b/lib/src/main/java/com/wjduquette/joe/app/NeroTool.java
@@ -1,7 +1,7 @@
 package com.wjduquette.joe.app;
 
 import com.wjduquette.joe.*;
-import com.wjduquette.joe.nero.Nero;
+import com.wjduquette.joe.nero.NeroEngine;
 import com.wjduquette.joe.nero.Fact;
 import com.wjduquette.joe.nero.RuleSetCompiler;
 import com.wjduquette.joe.parser.ASTRuleSet;
@@ -170,14 +170,14 @@ public class NeroTool implements Tool {
      * @param buff The Nero source.
      * @throws JoeError if the script could not be compiled.
      */
-    public Nero compile(SourceBuffer buff) {
+    public NeroEngine compile(SourceBuffer buff) {
         // FIRST, compile the source.
         var ast = parse(buff);
         var compiler = new RuleSetCompiler(ast);
         var ruleset = compiler.compile();
 
         // Will throw JoeError if the rules aren't stratified.
-        var nero = new Nero(ruleset);
+        var nero = new NeroEngine(ruleset);
         nero.setDebug(debug);
         nero.infer();
         return nero;

--- a/lib/src/main/java/com/wjduquette/joe/app/NeroTool.java
+++ b/lib/src/main/java/com/wjduquette/joe/app/NeroTool.java
@@ -1,11 +1,8 @@
 package com.wjduquette.joe.app;
 
 import com.wjduquette.joe.*;
-import com.wjduquette.joe.nero.NeroEngine;
+import com.wjduquette.joe.nero.Nero;
 import com.wjduquette.joe.nero.Fact;
-import com.wjduquette.joe.nero.RuleSetCompiler;
-import com.wjduquette.joe.parser.ASTRuleSet;
-import com.wjduquette.joe.parser.Parser;
 import com.wjduquette.joe.tools.Tool;
 import com.wjduquette.joe.tools.ToolInfo;
 
@@ -47,12 +44,11 @@ public class NeroTool implements Tool {
     //-------------------------------------------------------------------------
     // Instance Variables
 
+    private final Nero nero = new Nero();
+
     private boolean dumpAST = false;
-    private boolean debug = false;
     private boolean dumpAll = false;
     private final List<String> relations = new ArrayList<>();
-
-    private boolean gotParseError = false;
 
     //-------------------------------------------------------------------------
     // Constructor
@@ -82,7 +78,7 @@ public class NeroTool implements Tool {
             switch (opt) {
                 case "--ast", "-a"      -> dumpAST = true;
                 case "--all"            -> dumpAll = true;
-                case "--debug", "-d"    -> debug = true;
+                case "--debug", "-d"    -> nero.setDebug(true);
                 case "--relation", "-r" ->
                     relations.add(toOptArg(opt, argq));
                 default -> {
@@ -115,22 +111,22 @@ public class NeroTool implements Tool {
 
         try {
             // FIRST, dump the AST if they asked for that.
-            if (dumpAST) dumpAST(source);
+            if (dumpAST) println(nero.dumpAST(source));
 
             // NEXT, compile and execute it.
-            var nero = compile(source);
+            var results = nero.execute(source);
 
             if (dumpNew) {
-                var newFacts = new HashSet<>(nero.getInferredFacts());
-                newFacts.removeAll(nero.getAxioms());
+                var newFacts = new HashSet<>(results.getInferredFacts());
+                newFacts.removeAll(results.getAxioms());
                 dumpFacts("New Facts:", newFacts);
             } else if (dumpAll) {
                 // If we dump everything, no need to do specific queries.
-                dumpFacts("All Facts:", nero.getAllFacts());
+                dumpFacts("All Facts:", results.getAllFacts());
             } else {
                 for (var relation : relations) {
                     dumpFacts("Relation: " + relation,
-                        nero.getFacts(relation));
+                        results.getFacts(relation));
                 }
             }
         } catch (SyntaxError ex) {
@@ -141,11 +137,6 @@ public class NeroTool implements Tool {
             System.err.println(ex.getMessage());
             System.exit(1);
         }
-    }
-
-    private void dumpAST(SourceBuffer source) {
-        var ast = parse(source);
-        println(ast);
     }
 
     /**
@@ -161,39 +152,6 @@ public class NeroTool implements Tool {
         var script = new String(bytes, Charset.defaultCharset());
 
         return new SourceBuffer(path.getFileName().toString(), script);
-    }
-
-    /**
-     * Just a convenient entry point for getting some source code into
-     * the module.  This will undoubtedly change a lot over time.
-     *
-     * @param buff The Nero source.
-     * @throws JoeError if the script could not be compiled.
-     */
-    public NeroEngine compile(SourceBuffer buff) {
-        // FIRST, compile the source.
-        var ast = parse(buff);
-        var compiler = new RuleSetCompiler(ast);
-        var ruleset = compiler.compile();
-
-        // Will throw JoeError if the rules aren't stratified.
-        var nero = new NeroEngine(ruleset);
-        nero.setDebug(debug);
-        nero.infer();
-        return nero;
-    }
-
-    public ASTRuleSet parse(SourceBuffer source) {
-        var parser = new Parser(source, this::errorHandler);
-        var ast = parser.parseNero();
-        if (gotParseError) throw new JoeError("Error in Nero input.");
-        return ast;
-    }
-
-    private void errorHandler(Trace trace, boolean incomplete) {
-        gotParseError = true;
-        System.out.println("line " + trace.line() + ": " +
-            trace.message());
     }
 
     private void dumpFacts(String title, Collection<Fact> facts) {

--- a/lib/src/main/java/com/wjduquette/joe/nero/Fact.java
+++ b/lib/src/main/java/com/wjduquette/joe/nero/Fact.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * {@link Nero} analyzes input Facts and infers output facts based on
+ * {@link NeroEngine} analyzes input Facts and infers output facts based on
  * {@link Rule Rules} in the Nero rule set.  Any object that implements the
  * Fact interface can be used as an input fact.
  *

--- a/lib/src/main/java/com/wjduquette/joe/nero/ListFact.java
+++ b/lib/src/main/java/com/wjduquette/joe/nero/ListFact.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * A {@link Nero} {@link Fact} type providing efficient ordered-field access
+ * A {@link NeroEngine} {@link Fact} type providing efficient ordered-field access
  * to a list of field values.  Field names are `f0`, `f1`, `f2`, etc.
  * @param relation The relation
  * @param fields The values.

--- a/lib/src/main/java/com/wjduquette/joe/nero/MapFact.java
+++ b/lib/src/main/java/com/wjduquette/joe/nero/MapFact.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * A {@link Nero} {@link Fact} type providing efficient named-field access
+ * A {@link NeroEngine} {@link Fact} type providing efficient named-field access
  * to a map of field names and values.
  * @param relation The relation
  * @param fieldMap The values.

--- a/lib/src/main/java/com/wjduquette/joe/nero/Nero.java
+++ b/lib/src/main/java/com/wjduquette/joe/nero/Nero.java
@@ -1,0 +1,118 @@
+package com.wjduquette.joe.nero;
+
+import com.wjduquette.joe.*;
+import com.wjduquette.joe.parser.ASTRuleSet;
+import com.wjduquette.joe.parser.Parser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The Nero class provides standalone parsing and execution of Nero scripts.
+ * It is the Nero equivalent of the
+ * {@link com.wjduquette.joe.Joe} class, and provides the API used
+ * by the `joe nero` tool and by other clients wishing to load and execute
+ * standalone Nero scripts.
+ */
+public class Nero {
+    //-------------------------------------------------------------------------
+    // Instance Variables
+
+    // The debug flag
+    private boolean debug = false;
+
+    // Any error traces.
+    private List<Trace> traces = null;
+
+    //-------------------------------------------------------------------------
+    // Constructor
+
+    public Nero() {
+        // Nothing to do
+    }
+
+    //-------------------------------------------------------------------------
+    // Internals
+
+    // Compiles the source to a NeroEngine, and checks for stratification.
+    // Throws SyntaxError on any parse error and JoeError if the rule set
+    // is not stratified.
+    private NeroEngine compile(SourceBuffer source) {
+        var ast = parse(source);
+        var ruleSet = new RuleSetCompiler(ast).compile();
+        if (!ruleSet.isStratified()) {
+            throw new JoeError("Nero rule set is not stratified.");
+        }
+        var engine = new NeroEngine(ruleSet);
+        engine.setDebug(debug);
+
+        return engine;
+    }
+
+    // Parses the source, throwing a SyntaxError on error.
+    private ASTRuleSet parse(SourceBuffer source) {
+        traces = new ArrayList<>();
+        var parser = new Parser(source, this::errorHandler);
+        var ast = parser.parseNero();
+        if (!traces.isEmpty()) {
+            var error = new SyntaxError("Error in Nero input.", traces, false);
+            traces = null;
+            throw error;
+        }
+        return ast;
+    }
+
+    private void errorHandler(Trace trace, boolean incomplete) {
+        traces.add(trace);
+    }
+
+    //-------------------------------------------------------------------------
+    // Public API
+
+    /**
+     * Gets whether Joe is configured for debugging output.
+     * @return true or false
+     */
+    public boolean isDebug() {
+        return debug;
+    }
+
+    /**
+     * Sets whether Joe is configured for debugging output.  This
+     * is primarily of use to the Joe maintainer.
+     * @param flag true or false
+     */
+    public void setDebug(boolean flag) {
+        this.debug = flag;
+    }
+
+    /**
+     * Executes the Nero script, throwing an appropriate error on failure
+     * and returning a NeroEngine containing the results on success.
+     * The filename is usually the bare file name of the script file,
+     * but can be any string relevant to the application.
+     * @param source The source buffer
+     * @return The NeroEngine
+     * @throws SyntaxError if the script could not be compiled.
+     * @throws JoeError on all runtime errors.
+     */
+    public NeroEngine execute(SourceBuffer source)
+        throws SyntaxError, JoeError
+    {
+        var engine = compile(source);
+        engine.setDebug(debug);
+        engine.infer();
+        return engine;
+    }
+
+    /**
+     * Parses the Nero script, returning a text dump of the resulting
+     * Abstract Syntax Tree (AST).
+     * @param source The source buffer
+     * @return The string
+     * @throws SyntaxError on any parsing error.
+     */
+    public String dumpAST(SourceBuffer source) throws SyntaxError {
+        return parse(source).toString();
+    }
+}

--- a/lib/src/main/java/com/wjduquette/joe/nero/NeroEngine.java
+++ b/lib/src/main/java/com/wjduquette/joe/nero/NeroEngine.java
@@ -9,7 +9,7 @@ import java.util.*;
  * an additional set of input {@link Fact Facts}, Nero will infer the
  * new Facts implied by the input and the RuleSet's {@link Rule Rules}.
  */
-public class Nero {
+public class NeroEngine {
     //-------------------------------------------------------------------------
     // Static
 
@@ -17,7 +17,7 @@ public class Nero {
      * Nero's default fact factory; it creates {@link ListFact} objects.
      */
     public static final FactFactory DEFAULT_FACT_FACTORY =
-        Nero::defaultFactFactory;
+        NeroEngine::defaultFactFactory;
 
     private static Fact defaultFactFactory(String relation, List<Object> terms) {
         return new ListFact(relation, terms);
@@ -54,7 +54,7 @@ public class Nero {
      * Creates an instance of Nero for the given {@link RuleSet}.
      * @param ruleset The rule set.
      */
-    public Nero(RuleSet ruleset) {
+    public NeroEngine(RuleSet ruleset) {
         this.ruleset = ruleset;
 
         // NEXT, Categorize the rules by head relation

--- a/lib/src/main/java/com/wjduquette/joe/nero/RecordFact.java
+++ b/lib/src/main/java/com/wjduquette/joe/nero/RecordFact.java
@@ -6,7 +6,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
- * A {@link Nero} {@link Fact} type providing both ordered and named-field
+ * A {@link NeroEngine} {@link Fact} type providing both ordered and named-field
  * access with provided field names.
  *
  * <p>This type is designed for use with Joe's scripted records, which

--- a/lib/src/main/java/com/wjduquette/joe/types/FactBaseType.java
+++ b/lib/src/main/java/com/wjduquette/joe/types/FactBaseType.java
@@ -3,7 +3,7 @@ package com.wjduquette.joe.types;
 import com.wjduquette.joe.*;
 import com.wjduquette.joe.nero.Fact;
 import com.wjduquette.joe.nero.FactSet;
-import com.wjduquette.joe.nero.NeroEngine;
+import com.wjduquette.joe.nero.Nero;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -141,11 +141,9 @@ public class FactBaseType extends ProxyType<FactBase> {
     private Object _fromNero(Joe joe, Args args) {
         args.exactArity(1, "FactBase.fromNero(script)");
         var script = joe.toString(args.next());
-        var ruleset = JoeNero.compile(script);
-        var nero = new NeroEngine(ruleset);
-        nero.infer();
+        var results = new Nero().execute(new SourceBuffer("*fromNero*", script));
         var db = new FactBase();
-        db.addAll(nero.getAllFacts());
+        db.addAll(results.getAllFacts());
         return db;
     }
 

--- a/lib/src/main/java/com/wjduquette/joe/types/FactBaseType.java
+++ b/lib/src/main/java/com/wjduquette/joe/types/FactBaseType.java
@@ -3,7 +3,7 @@ package com.wjduquette.joe.types;
 import com.wjduquette.joe.*;
 import com.wjduquette.joe.nero.Fact;
 import com.wjduquette.joe.nero.FactSet;
-import com.wjduquette.joe.nero.Nero;
+import com.wjduquette.joe.nero.NeroEngine;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -142,7 +142,7 @@ public class FactBaseType extends ProxyType<FactBase> {
         args.exactArity(1, "FactBase.fromNero(script)");
         var script = joe.toString(args.next());
         var ruleset = JoeNero.compile(script);
-        var nero = new Nero(ruleset);
+        var nero = new NeroEngine(ruleset);
         nero.infer();
         var db = new FactBase();
         db.addAll(nero.getAllFacts());

--- a/lib/src/test/java/com/wjduquette/joe/nero/NeroEngineTest.java
+++ b/lib/src/test/java/com/wjduquette/joe/nero/NeroEngineTest.java
@@ -13,7 +13,7 @@ import static com.wjduquette.joe.checker.Checker.check;
 
 // Tests for the Nero engine. This test suite does NOT check for parsing
 // errors.
-public class NeroTest extends Ted {
+public class NeroEngineTest extends Ted {
     @Test
     public void testSimple() {
         test("testSimple");
@@ -162,12 +162,12 @@ public class NeroTest extends Ted {
 
     private boolean gotParseError = false;
 
-    private Nero compile(String source) {
+    private NeroEngine compile(String source) {
         gotParseError = false;
         var buff = new SourceBuffer("-", source);
         var ast = parse(buff);
         var ruleset = new RuleSetCompiler(ast).compile();
-        return new Nero(ruleset);
+        return new NeroEngine(ruleset);
     }
 
     public ASTRuleSet parse(SourceBuffer source) {


### PR DESCRIPTION
This pull request revises the internal Nero API to avoid duplication.

- The `Nero` engine is now called `NeroEngine`.
- A new `Nero` class provides an API for processing of standalone Nero scripts.
- The `joe nero` tool now uses this API.
- The `FactBase.fromNero` method now uses this API.