### PR TITLE
Built-in Nero Predicates

### DIFF
--- a/lib/src/main/java/com/wjduquette/joe/nero/RuleEngine.java
+++ b/lib/src/main/java/com/wjduquette/joe/nero/RuleEngine.java
@@ -18,13 +18,16 @@ public class RuleEngine {
     // Static Built-In Predicate Schema
 
     private static final Schema BUILT_INS = new Schema();
+    public static final String MEMBER = "member";
+    public static final String INDEXED_MEMBER = "indexedMember";
+    public static final String KEYED_MEMBER = "keyedMember";
 
     static {
-        BUILT_INS.checkAndAdd(new Shape.PairShape("member",
+        BUILT_INS.checkAndAdd(new Shape.PairShape(MEMBER,
             List.of("item", "collection")));
-        BUILT_INS.checkAndAdd(new Shape.PairShape("indexedMember",
+        BUILT_INS.checkAndAdd(new Shape.PairShape(INDEXED_MEMBER,
             List.of("index", "item", "list")));
-        BUILT_INS.checkAndAdd(new Shape.PairShape("keyedMember",
+        BUILT_INS.checkAndAdd(new Shape.PairShape(KEYED_MEMBER,
             List.of("key", "value", "map")));
     }
 
@@ -40,16 +43,14 @@ public class RuleEngine {
     }
 
     /**
-     * Returns true if the atom's relation names a built-in predicate
-     * and the atom's shape is conformable to the predicate's shape,
-     * and false otherwise.
-     * @param atom The atom
-     * @return true or false.
+     * Gets the relation's shape from the built-in predicate's schema.
+     * @param relation The relation
+     * @return The shape or null.
      */
-    public static boolean hasBuiltInShape(Atom atom) {
-        var shape = BUILT_INS.get(atom.relation());
-        return shape != null && Shape.conformsTo(atom, shape);
+    public static Shape getBuiltInShape(String relation) {
+        return BUILT_INS.get(relation);
     }
+
 
     //-------------------------------------------------------------------------
     // Instance Variables

--- a/lib/src/main/java/com/wjduquette/joe/nero/RuleEngine.java
+++ b/lib/src/main/java/com/wjduquette/joe/nero/RuleEngine.java
@@ -252,7 +252,9 @@ public class RuleEngine {
             // The NeroParser ensures that atom conforms to the built-in's shape.
             // TODO: Make BindingContext static, and add a registry.
             facts = switch (atom.relation()) {
-                case "member" -> _member(bc, atom);
+                case MEMBER -> _member(bc, atom);
+                case INDEXED_MEMBER -> _indexedMember(bc, atom);
+                case KEYED_MEMBER -> _keyedMember(bc, atom);
                 default -> throw new UnsupportedOperationException("TODO");
             };
         } else {
@@ -511,15 +513,45 @@ public class RuleEngine {
     // Built-In Predicates
 
     // member/item,collection
-    //
-    // The collection
     private Set<Fact> _member(BindingContext bc, Atom atom) {
         var coll = extractVar(bc, atom, 1);
 
         var facts = new HashSet<Fact>();
         if (coll instanceof Collection<?> c) {
             for (var item : c) {
-                facts.add(new ListFact("member", List.of(item, c)));
+                facts.add(new ListFact(MEMBER, List.of(item, c)));
+            }
+        }
+
+        return facts;
+    }
+
+    // indexedMember/index,item,list
+    private Set<Fact> _indexedMember(BindingContext bc, Atom atom) {
+        var coll = extractVar(bc, atom, 2);
+
+        var facts = new HashSet<Fact>();
+        if (coll instanceof List<?> list) {
+            int index = 0;
+            for (var item : list) {
+                facts.add(new ListFact(INDEXED_MEMBER,
+                    List.of((double)index, item, list)));
+                ++index;
+            }
+        }
+
+        return facts;
+    }
+
+    // keyedMember/key,value,map
+    private Set<Fact> _keyedMember(BindingContext bc, Atom atom) {
+        var coll = extractVar(bc, atom, 2);
+        var facts = new HashSet<Fact>();
+
+        if (coll instanceof Map<?,?> map) {
+            for (var e : map.entrySet()) {
+                facts.add(new ListFact(KEYED_MEMBER,
+                    List.of(e.getKey(), e.getValue(), map)));
             }
         }
 

--- a/lib/src/main/java/com/wjduquette/joe/nero/Schema.java
+++ b/lib/src/main/java/com/wjduquette/joe/nero/Schema.java
@@ -79,7 +79,7 @@ public class Schema {
      * @return true or false
      */
     public boolean checkAndAdd(Fact fact) {
-        var shape = Shape.infer(fact);
+        var shape = Shape.inferShape(fact);
         return checkAndAdd(shape);
     }
 
@@ -106,21 +106,12 @@ public class Schema {
 
         // FIRST, save the inferred shape if there's no shape already defined.
         if (defined == null) {
-            shapeMap.put(relation, Shape.infer(head));
+            shapeMap.put(relation, Shape.inferDefaultShape(head));
             return true;
         }
 
         // NEXT, make sure the atom is compatible with the defined shape.
-        return switch (defined) {
-            case Shape.ListShape s ->
-                head instanceof OrderedAtom a &&
-                s.arity() == a.terms().size();
-            case Shape.MapShape ignored ->
-                head instanceof NamedAtom;
-            case Shape.PairShape s ->
-                head instanceof OrderedAtom a &&
-                s.arity() == a.terms().size();
-        };
+        return Shape.conformsTo(head, defined);
     }
 
     //-------------------------------------------------------------------------

--- a/lib/src/main/java/com/wjduquette/joe/nero/Shape.java
+++ b/lib/src/main/java/com/wjduquette/joe/nero/Shape.java
@@ -78,7 +78,7 @@ public sealed interface Shape permits
      * @param fact The fact
      * @return The shape
      */
-    static Shape infer(Fact fact) {
+    static Shape inferShape(Fact fact) {
         return switch (fact) {
             case ListFact f -> new ListShape(f.relation(), f.arity());
             case MapFact f  -> new MapShape(f.relation());
@@ -87,15 +87,35 @@ public sealed interface Shape permits
     }
 
     /**
-     * Infer the shape of a fact from a rule or axiom head atom.  Infers the
+     * Infer the default shape of a fact from a rule or axiom head atom.  Infers the
      * list shape for ordered atoms and the map shape for named atoms.
      * @param head The head atom
      * @return The inferred shape
      */
-    static Shape infer(Atom head) {
+    static Shape inferDefaultShape(Atom head) {
         return switch (head) {
             case OrderedAtom a -> new ListShape(a.relation(), a.terms().size());
             case NamedAtom a -> new MapShape(a.relation());
+        };
+    }
+
+    /**
+     * Returns true if the atom conforms to the given Shape, and false
+     * otherwise.
+     * @param atom The atom
+     * @param shape The shape
+     * @return true or false
+     */
+    static boolean conformsTo(Atom atom, Shape shape) {
+        return switch (shape) {
+            case Shape.ListShape s ->
+                atom instanceof OrderedAtom a &&
+                    s.arity() == a.terms().size();
+            case Shape.MapShape ignored ->
+                atom instanceof NamedAtom;
+            case Shape.PairShape s ->
+                atom instanceof OrderedAtom a &&
+                    s.arity() == a.terms().size();
         };
     }
 }

--- a/lib/src/main/java/com/wjduquette/joe/parser/NeroParser.java
+++ b/lib/src/main/java/com/wjduquette/joe/parser/NeroParser.java
@@ -6,6 +6,7 @@ import com.wjduquette.joe.scanner.Token;
 import java.util.*;
 import java.util.function.Supplier;
 
+import static com.wjduquette.joe.nero.RuleEngine.*;
 import static com.wjduquette.joe.scanner.TokenType.*;
 
 /**
@@ -74,6 +75,11 @@ class NeroParser extends EmbeddedParser {
                 var headToken = scanner.peek();
                 var head = atom();
 
+                if (RuleEngine.isBuiltIn(head.relation())) {
+                    throw errorSync(headToken,
+                        "found built-in predicate in axiom or rule head.");
+                }
+
                 if (scanner.match(SEMICOLON)) {
                     if (!schema.checkAndAdd(head)) {
                         error(headToken,
@@ -103,6 +109,11 @@ class NeroParser extends EmbeddedParser {
         scanner.consume(IDENTIFIER, "expected relation after 'define'.");
         var relation = scanner.previous();
         scanner.consume(SLASH, "expected '/' after relation.");
+
+        if (RuleEngine.isBuiltIn(relation.lexeme())) {
+            throw errorSync(relation,
+                "found built-in predicate in 'define' declaration.");
+        }
 
         Shape shape;
 
@@ -157,7 +168,7 @@ class NeroParser extends EmbeddedParser {
         var body = new ArrayList<Atom>();
         var negations = new ArrayList<Atom>();
         var constraints = new ArrayList<Constraint>();
-        var bodyVar = new HashSet<String>();
+        var bodyVars = new HashSet<String>();
 
         do {
             var negated = scanner.match(NOT);
@@ -165,8 +176,12 @@ class NeroParser extends EmbeddedParser {
             var token = scanner.peek();
             var atom = atom();
             if (negated) {
+                if (RuleEngine.isBuiltIn(atom.relation())) {
+                    throw errorSync(headToken,
+                        "found built-in predicate in negated body atom.");
+                }
                 for (var name : atom.getVariableNames()) {
-                    if (!bodyVar.contains(name)) {
+                    if (!bodyVars.contains(name)) {
                         error(token,
                             "negated body atom contains unbound variable: '" +
                             name + "'.");
@@ -174,14 +189,17 @@ class NeroParser extends EmbeddedParser {
                 }
                 negations.add(atom);
             } else {
+                if (RuleEngine.isBuiltIn(atom.relation())) {
+                    checkBuiltIn(token, bodyVars, atom);
+                }
                 body.add(atom);
-                bodyVar.addAll(atom.getVariableNames());
+                bodyVars.addAll(atom.getVariableNames());
             }
         } while (scanner.match(COMMA));
 
         if (scanner.match(WHERE)) {
             do {
-                constraints.add(constraint(bodyVar));
+                constraints.add(constraint(bodyVars));
             } while (scanner.match(COMMA));
         }
 
@@ -192,7 +210,7 @@ class NeroParser extends EmbeddedParser {
             switch (term) {
                 case Constant ignored -> {}
                 case Variable v -> {
-                    if (!bodyVar.contains(v.name())) {
+                    if (!bodyVars.contains(v.name())) {
                         error(headToken,
                             "head atom contains unbound variable: '" +
                             v.name() + "'.");
@@ -204,6 +222,44 @@ class NeroParser extends EmbeddedParser {
         }
 
         return new Rule(head, body, negations, constraints);
+    }
+
+    // Verify that this is a valid built-in.
+    private void checkBuiltIn(Token token, Set<String> bodyVars, Atom atom) {
+        var shape = RuleEngine.getBuiltInShape(atom.relation());
+        assert shape != null;
+        if (!Shape.conformsTo(atom, shape)) {
+            error(token, "expected " + shape.toSpec() + ", got: " +
+                Shape.inferDefaultShape(atom).toSpec() + ".");
+            return;
+        }
+
+        switch (atom.relation()) {
+            case MEMBER ->
+                requireBound(token, bodyVars, atom, 1);
+            case INDEXED_MEMBER, KEYED_MEMBER ->
+                requireBound(token, bodyVars, atom, 2);
+            default -> throw new IllegalStateException(
+                "Unexpected built-in-predicate: '" + atom.relation() + "'.");
+        }
+    }
+
+    // Checks whether the index'th term in the atom is a bound variable.
+    private void requireBound(
+        Token relation,
+        Set<String> bodyVars,
+        Atom atom,
+        int index
+    ) {
+        // We've checked the shape of the atom, and it conforms to a
+        // built-in predicate; therefore it is an OrderedAtom, and it
+        // has the expected number of terms.
+        assert atom instanceof OrderedAtom;
+        var a = (OrderedAtom)atom;
+        var term = a.terms().get(index);
+        if (term instanceof Variable v && bodyVars.contains(v.name())) return;
+        error(relation, "expected bound variable as term " + index +
+            ", got: " + term);
     }
 
     private Constraint constraint(Set<String> bodyVar) {

--- a/lib/src/main/java/com/wjduquette/joe/types/RuleSetType.java
+++ b/lib/src/main/java/com/wjduquette/joe/types/RuleSetType.java
@@ -81,9 +81,9 @@ public class RuleSetType extends ProxyType<RuleSetValue> {
     private Object _infer(RuleSetValue value, Joe joe, Args args) {
         args.arityRange(0, 1, "infer([inputs])");
         if (args.isEmpty()) {
-            return joe.readonlySet(value.infer());
+            return new SetValue(value.infer());
         } else {
-            return joe.readonlySet(value.infer(joe,
+            return new SetValue(value.infer(joe,
                 joe.toCollection(args.next())));
         }
     }

--- a/lib/src/test/java/com/wjduquette/joe/nero/SchemaTest.java
+++ b/lib/src/test/java/com/wjduquette/joe/nero/SchemaTest.java
@@ -84,7 +84,7 @@ public class SchemaTest extends Ted {
         test("testCheckAndAdd_fact_new");
 
         var fact = new ListFact("Person", List.of("Joe", 90));
-        var shape = Shape.infer(fact);
+        var shape = Shape.inferShape(fact);
         check(schema.checkAndAdd(fact)).eq(true);
 
         check(schema.getRelations()).eq(Set.of("Person"));
@@ -135,7 +135,7 @@ public class SchemaTest extends Ted {
 
         var ast = parse("Person(#a, #b);");
         var head = new ArrayList<>(ast.axioms()).getFirst();
-        var shape = Shape.infer(head);
+        var shape = Shape.inferDefaultShape(head);
         check(schema.checkAndAdd(head)).eq(true);
 
         check(schema.getRelations()).eq(Set.of("Person"));

--- a/lib/src/test/java/com/wjduquette/joe/nero/ShapeTest.java
+++ b/lib/src/test/java/com/wjduquette/joe/nero/ShapeTest.java
@@ -21,7 +21,7 @@ public class ShapeTest extends Ted {
     @Test
     public void testInfer_fact_list() {
         test("testInfer_fact_list");
-        var shape = (Shape.ListShape)Shape.infer(LIST_FACT);
+        var shape = (Shape.ListShape)Shape.inferShape(LIST_FACT);
         check(shape.relation()).eq("List");
         check(shape.arity()).eq(2);
         check(shape.toString()).eq("ListShape[relation=List, arity=2]");
@@ -31,7 +31,7 @@ public class ShapeTest extends Ted {
     @Test
     public void testInfer_fact_map() {
         test("testInfer_fact_map");
-        var shape = (Shape.MapShape)Shape.infer(MAP_FACT);
+        var shape = (Shape.MapShape)Shape.inferShape(MAP_FACT);
         check(shape.relation()).eq("Map");
         check(shape.arity()).eq(-1);
         check(shape.toString()).eq("MapShape[relation=Map]");
@@ -41,7 +41,7 @@ public class ShapeTest extends Ted {
     @Test
     public void testInfer_fact_pair() {
         test("testInfer_fact_pair");
-        var shape = (Shape.PairShape)Shape.infer(PAIR_FACT);
+        var shape = (Shape.PairShape)Shape.inferShape(PAIR_FACT);
         check(shape.relation()).eq("Pair");
         check(shape.arity()).eq(2);
         check(shape.toString()).eq("PairShape[relation=Pair, fieldNames=[a, b]]");
@@ -54,7 +54,7 @@ public class ShapeTest extends Ted {
 
         var ast = parse("List(#a, #b);");
         var axioms = new ArrayList<>(ast.axioms());
-        var shape = (Shape.ListShape)Shape.infer(axioms.getFirst());
+        var shape = (Shape.ListShape)Shape.inferDefaultShape(axioms.getFirst());
 
         check(shape.relation()).eq("List");
         check(shape.arity()).eq(2);
@@ -67,7 +67,7 @@ public class ShapeTest extends Ted {
 
         var ast = parse("Map(x: #a, y: #b);");
         var axioms = new ArrayList<>(ast.axioms());
-        var shape = (Shape.MapShape)Shape.infer(axioms.getFirst());
+        var shape = (Shape.MapShape)Shape.inferDefaultShape(axioms.getFirst());
 
         check(shape.relation()).eq("Map");
         check(shape.toString()).eq("MapShape[relation=Map]");

--- a/lib/src/test/java/com/wjduquette/joe/parser/NeroParserTest.java
+++ b/lib/src/test/java/com/wjduquette/joe/parser/NeroParserTest.java
@@ -26,6 +26,26 @@ public class NeroParserTest extends Ted {
     //-------------------------------------------------------------------------
     // parse()
 
+    @Test public void testParse_axiomBuiltIn() {
+        test("testParse_axiomBuiltIn");
+
+        var source = """
+            member(#joe, 90);
+            """;
+        check(parseNero(source))
+            .eq("[line 1] error at 'member', found built-in predicate in axiom.");
+    }
+
+    @Test public void testParse_ruleHeadBuiltIn() {
+        test("testParse_axiomBuiltIn");
+
+        var source = """
+            member(x, y) :- Foo(x, y);
+            """;
+        check(parseNero(source))
+            .eq("[line 1] error at 'member', found built-in predicate in rule head.");
+    }
+
     @Test public void testParse_axiomMismatch() {
         test("testParse_axiomMismatch");
 
@@ -70,6 +90,16 @@ public class NeroParserTest extends Ted {
             """;
         check(parseNero(source))
             .eq("[line 1] error at '2', expected relation after 'define'.");
+    }
+
+    @Test public void testDefineDeclaration_foundBuiltIn() {
+        test("testDefineDeclaration_foundBuiltIn");
+
+        var source = """
+            define member/2;
+            """;
+        check(parseNero(source))
+            .eq("[line 1] error at 'member', found built-in predicate in 'define' declaration.");
     }
 
     @Test public void testDefineDeclaration_expectedSlash() {
@@ -193,6 +223,16 @@ public class NeroParserTest extends Ted {
     //-------------------------------------------------------------------------
     // rule()
 
+    @Test public void testRule_negatedMember() {
+        test("testRule_negatedMember");
+
+        var source = """
+            Thing(x) :- Foo(list), Bar(x), not member(x, list);
+            """;
+        check(parseNero(source))
+            .eq("[line 1] error at 'member', found built-in predicate in negated body atom.");
+    }
+
     @Test public void testRule_negatedUnbound() {
         test("testRule_negatedUnbound");
 
@@ -232,6 +272,45 @@ public class NeroParserTest extends Ted {
             """;
         check(parseNero(source))
             .eq("[line 1] error at 'Thing', head atom contains wildcard: '_'.");
+    }
+
+    //-------------------------------------------------------------------------
+    // checkBuiltIn()
+
+    @Test public void testCheckBuiltIn_shape() {
+        test("testCheckBuiltIn_shape");
+        var source = """
+            Thing(x) :- Foo(list), member(x, list, y);
+            """;
+        check(parseNero(source))
+            .eq("[line 1] error at 'member', expected member/item,collection, got: member/3.");
+    }
+
+    @Test public void testCheckBuiltIn_memberUnbound() {
+        test("testCheckBuiltIn_memberUnbound");
+        var source = """
+            Thing(x) :- Foo(list), member(x, items);
+            """;
+        check(parseNero(source))
+            .eq("[line 1] error at 'member', expected bound variable as term 1, got: 'items'.");
+    }
+
+    @Test public void testCheckBuiltIn_indexedMemberUnbound() {
+        test("testCheckBuiltIn_indexedMemberUnbound");
+        var source = """
+            Thing(x) :- Foo(list), indexedMember(i, x, items);
+            """;
+        check(parseNero(source))
+            .eq("[line 1] error at 'indexedMember', expected bound variable as term 2, got: 'items'.");
+    }
+
+    @Test public void testCheckBuiltIn_keyedMemberUnbound() {
+        test("testCheckBuiltIn_keyedMemberUnbound");
+        var source = """
+            Thing(x) :- Foo(map), keyedMember(k, v, items);
+            """;
+        check(parseNero(source))
+            .eq("[line 1] error at 'keyedMember', expected bound variable as term 2, got: 'items'.");
     }
 
     //-------------------------------------------------------------------------

--- a/tests/type.joe.RuleSet.joe
+++ b/tests/type.joe.RuleSet.joe
@@ -224,3 +224,157 @@ function testInfer_class_ordered() {
         "'Parent' in rule 'Ancestor(x, y) :- Parent(x, y);' requires ordered fields, but a provided fact is not ordered.");
 }
 
+//=============================================================================
+// Built-in Predicates
+
+function testMember_disaggregate() {
+    record Owner(id, list) {}
+
+    var inputs = [
+        Owner(#joe, [#hat, #boots, #truck])
+    ];
+
+    var rules = ruleset {
+        Owns(id, item) :- Owner(id, list), member(item, list);
+    };
+    var results = rules.infer(inputs);
+
+    check(results).eq({
+        Fact("Owns", #joe, #hat),
+        Fact("Owns", #joe, #boots),
+        Fact("Owns", #joe, #truck),
+    });
+}
+
+function testMember_match() {
+    record Owner(id, list) {}
+
+    var inputs = [
+        Owner(#joe, [#hat, #boots, #truck])
+    ];
+
+    var rules = ruleset {
+        OwnsHat(id) :- Owner(id, list), member(#hat, list);
+    };
+    var results = rules.infer(inputs);
+
+    check(results).eq({
+        Fact("OwnsHat", #joe),
+    });
+}
+
+function testMember_noCollection() {
+    record Owner(id, list) {}
+
+    var inputs = [
+        Owner(#joe, #notCollection)
+    ];
+
+    var rules = ruleset {
+        Owns(id, item) :- Owner(id, list), member(item, list);
+    };
+    var results = rules.infer(inputs);
+
+    check(results).eq({});
+}
+
+function testIndexedMember_disaggregate() {
+    record Owner(id, list) {}
+
+    var inputs = [
+        Owner(#joe, [#hat, #boots, #truck])
+    ];
+
+    var rules = ruleset {
+        Owns(id, i, item) :- Owner(id, list), indexedMember(i, item, list);
+    };
+    var results = rules.infer(inputs);
+
+    check(results).eq({
+        Fact("Owns", #joe, 0, #hat),
+        Fact("Owns", #joe, 1, #boots),
+        Fact("Owns", #joe, 2, #truck),
+    });
+}
+
+function testIndexedMember_match() {
+    record Owner(id, list) {}
+
+    var inputs = [
+        Owner(#joe, [#hat, #boots, #truck])
+    ];
+
+    var rules = ruleset {
+        OwnsHat(id, i) :- Owner(id, list), indexedMember(i, #hat, list);
+    };
+    var results = rules.infer(inputs);
+
+    check(results).eq({
+        Fact("OwnsHat", #joe, 0),
+    });
+}
+
+function testIndexedMember_noCollection() {
+    record Owner(id, list) {}
+
+    var inputs = [
+        Owner(#joe, #notCollection)
+    ];
+
+    var rules = ruleset {
+        Owns(id, i, item) :- Owner(id, list), indexedMember(i, item, list);
+    };
+    var results = rules.infer(inputs);
+
+    check(results).eq({});
+}
+
+function testKeyedMember_disaggregate() {
+    record Owner(id, map) {}
+
+    var inputs = [
+        Owner(#joe, {#head: #hat, #feet: #boots})
+    ];
+
+    var rules = ruleset {
+        Wears(id, k, v) :- Owner(id, map), keyedMember(k, v, map);
+    };
+    var results = rules.infer(inputs);
+
+    check(results).eq({
+        Fact("Wears", #joe, #head, #hat),
+        Fact("Wears", #joe, #feet, #boots),
+    });
+}
+
+function testKeyedMember_match() {
+    record Owner(id, map) {}
+
+    var inputs = [
+        Owner(#joe, {#head: #hat, #feet: #boots})
+    ];
+
+    var rules = ruleset {
+        WearsHat(id, k) :- Owner(id, map), keyedMember(k, #hat, map);
+    };
+    var results = rules.infer(inputs);
+
+    check(results).eq({
+        Fact("WearsHat", #joe, #head),
+    });
+}
+
+function testKeyedMember_noCollection() {
+    record Owner(id, map) {}
+
+    var inputs = [
+        Owner(#joe, #notCollection)
+    ];
+
+    var rules = ruleset {
+        Wears(id, k, v) :- Owner(id, map), keyedMember(k, v, map);
+    };
+    var results = rules.infer(inputs);
+
+    check(results).eq({});
+}


### PR DESCRIPTION
This pull request adds three "built-in" predicates to Nero: `member`, `indexedMember`, 
`keyedMember`.