### PR TITLE
`Bindings` API

### DIFF
--- a/lib/src/main/java/com/wjduquette/joe/nero/Bindings.java
+++ b/lib/src/main/java/com/wjduquette/joe/nero/Bindings.java
@@ -7,19 +7,38 @@ import java.util.Map;
  * A map of variable bindings, used while matching
  * {@link Atom BodyAtoms} against {@link Fact Facts}.
  */
-public class Bindings extends HashMap<String,Object> {
+public class Bindings {
+    //-------------------------------------------------------------------------
+    // Instance Variables
+
+    private final Map<String,Object> map = new HashMap<>();
+
+    //-------------------------------------------------------------------------
+    // Constructor
+
     /**
      * Creates an empty set of bindings.
      */
     public Bindings() {
-        super();
+        // nothing to do
     }
 
     /**
      * Creates a set of bindings, initializing with the other bindings.
      * @param other The other bindings.
      */
-    public Bindings(Map<String,Object> other) {
-        super(other);
+    public Bindings(Bindings other) {
+        map.putAll(other.map);
+    }
+
+    //-------------------------------------------------------------------------
+    // API
+
+    public Object get(String name) {
+        return map.get(name);
+    }
+
+    public void bind(String name, Object value) {
+        map.put(name, value);
     }
 }

--- a/lib/src/main/java/com/wjduquette/joe/nero/Bindings.java
+++ b/lib/src/main/java/com/wjduquette/joe/nero/Bindings.java
@@ -7,7 +7,7 @@ import java.util.Map;
  * A map of variable bindings, used while matching
  * {@link Atom BodyAtoms} against {@link Fact Facts}.
  */
-public class Bindings extends HashMap<Variable,Object> {
+public class Bindings extends HashMap<String,Object> {
     /**
      * Creates an empty set of bindings.
      */
@@ -19,7 +19,7 @@ public class Bindings extends HashMap<Variable,Object> {
      * Creates a set of bindings, initializing with the other bindings.
      * @param other The other bindings.
      */
-    public Bindings(Map<Variable,Object> other) {
+    public Bindings(Map<String,Object> other) {
         super(other);
     }
 }

--- a/lib/src/main/java/com/wjduquette/joe/nero/RuleEngine.java
+++ b/lib/src/main/java/com/wjduquette/joe/nero/RuleEngine.java
@@ -352,7 +352,7 @@ public class RuleEngine {
                 var bound = bc.bindings.get(v.name());
 
                 if (bound == null) {
-                    bc.bindings.put(v.name(), value);
+                    bc.bindings.bind(v.name(), value);
                     yield true;
                 } else {
                     yield Objects.equals(bound, value);

--- a/lib/src/main/java/com/wjduquette/joe/nero/RuleEngine.java
+++ b/lib/src/main/java/com/wjduquette/joe/nero/RuleEngine.java
@@ -349,10 +349,10 @@ public class RuleEngine {
     ) {
         return switch (term) {
             case Variable v -> {
-                var bound = bc.bindings.get(v);
+                var bound = bc.bindings.get(v.name());
 
                 if (bound == null) {
-                    bc.bindings.put(v, value);
+                    bc.bindings.put(v.name(), value);
                     yield true;
                 } else {
                     yield Objects.equals(bound, value);
@@ -448,7 +448,7 @@ public class RuleEngine {
     private Object term2value(Term term, BindingContext bc) {
         return switch (term) {
             case Constant c -> c.value();
-            case Variable v -> bc.bindings.get(v);
+            case Variable v -> bc.bindings.get(v.name());
             case Wildcard ignored -> throw new IllegalStateException(
                 "Rule head contains a Wildcard term.");
         };
@@ -456,12 +456,12 @@ public class RuleEngine {
 
     private boolean constraintMet(
         Constraint constraint,
-        Map<Variable,Object> bindings
+        Bindings bindings
     ) {
-        var a = bindings.get(constraint.a());
+        var a = bindings.get(constraint.a().name());
 
         var b = switch (constraint.b()) {
-            case Variable v -> bindings.get(v);
+            case Variable v -> bindings.get(v.name());
             case Constant c -> c.value();
             case Wildcard ignored -> throw new IllegalStateException(
                 "Constraint contains a Wildcard term.");
@@ -564,7 +564,7 @@ public class RuleEngine {
         var term = a.terms().get(index);
         assert term instanceof Variable;
         var theVar = (Variable)term;
-        return bc.bindings.get(theVar);
+        return bc.bindings.get(theVar.name());
     }
 
     //-------------------------------------------------------------------------


### PR DESCRIPTION
`Bindings` now has a safer API.

It was a subclass of `Map<String,Object>`, and `Map::get` accepts any `Object` regardless of the key type.