### PR TITLE
Transient Nero relations

### DIFF
--- a/lib/src/main/java/com/wjduquette/joe/nero/RuleEngine.java
+++ b/lib/src/main/java/com/wjduquette/joe/nero/RuleEngine.java
@@ -104,7 +104,7 @@ public class RuleEngine {
 
     // Facts inferred from the rule set's axioms and rules (aka,
     // the "intensional database" in Datalog jargon).
-    private final Set<Fact> inferredFacts = new HashSet<>();
+    private final FactSet inferredFacts = new FactSet();
 
     //-------------------------------------------------------------------------
     // Constructor
@@ -180,7 +180,7 @@ public class RuleEngine {
         if (!inferenceComplete) {
             throw new IllegalStateException(INFER_ERROR);
         }
-        return inferredFacts;
+        return inferredFacts.getAll();
     }
 
     //-------------------------------------------------------------------------
@@ -226,6 +226,12 @@ public class RuleEngine {
 
         for (var i = 0; i < ruleset.strata().size(); i++) {
             inferStratum(i, ruleset.strata().get(i));
+        }
+
+        // NEXT, drop the transient relations.
+        for (var name : ruleset.schema().getTransients()) {
+            knownFacts.drop(name);
+            inferredFacts.drop(name);
         }
     }
 

--- a/lib/src/main/java/com/wjduquette/joe/nero/Schema.java
+++ b/lib/src/main/java/com/wjduquette/joe/nero/Schema.java
@@ -54,6 +54,10 @@ public class Schema {
         }
     }
 
+    public Set<String> getTransients() {
+        return transients;
+    }
+
     /**
      * Gets whether or not a shape is defined for this relation.
      * @param relation The relation

--- a/lib/src/main/java/com/wjduquette/joe/nero/Schema.java
+++ b/lib/src/main/java/com/wjduquette/joe/nero/Schema.java
@@ -15,7 +15,12 @@ public class Schema {
     //-------------------------------------------------------------------------
     // Instance Variables
 
+    // The relation shapes, by relation name.
     private final Map<String,Shape> shapeMap = new HashMap<>();
+
+    // The set of transient relations.  Transient relations are dropped after
+    // inference is complete.
+    private final Set<String> transients = new HashSet<>();
 
     //-------------------------------------------------------------------------
     // Constructor
@@ -26,6 +31,28 @@ public class Schema {
 
     //-------------------------------------------------------------------------
     // Public API
+
+    /**
+     * Returns true if the relation is marked transient in this schema.
+     * @param relation The relation name
+     * @return true or false
+     */
+    public boolean isTransient(String relation) {
+        return transients.contains(relation);
+    }
+
+    /**
+     * Sets/clears the transient flag for the given relation.
+     * @param relation The relation name
+     * @param flag The transient flag
+     */
+    public void setTransient(String relation, boolean flag) {
+        if (flag) {
+            transients.add(relation);
+        } else {
+            transients.remove(relation);
+        }
+    }
 
     /**
      * Gets whether or not a shape is defined for this relation.

--- a/lib/src/main/java/com/wjduquette/joe/parser/NeroParser.java
+++ b/lib/src/main/java/com/wjduquette/joe/parser/NeroParser.java
@@ -119,7 +119,10 @@ class NeroParser extends EmbeddedParser {
     }
 
     private void defineDeclaration(Schema schema) {
-        scanner.consume(IDENTIFIER, "expected relation after 'define'.");
+        var transience = scanner.matchIdentifier(TRANSIENT);
+
+        scanner.consume(IDENTIFIER,
+            "expected relation after 'define [transient]'.");
         var relation = scanner.previous();
 
         if (RuleEngine.isBuiltIn(relation.lexeme())) {
@@ -127,7 +130,6 @@ class NeroParser extends EmbeddedParser {
                 "found built-in predicate in 'define' declaration.");
         }
 
-        var transience = scanner.matchIdentifier(TRANSIENT);
 
         scanner.consume(SLASH, "expected '/' after relation.");
 

--- a/lib/src/test/java/com/wjduquette/joe/nero/SchemaTest.java
+++ b/lib/src/test/java/com/wjduquette/joe/nero/SchemaTest.java
@@ -32,6 +32,20 @@ public class SchemaTest extends Ted {
     }
 
     //-------------------------------------------------------------------------
+    // Transience
+
+    @Test public void testTransience() {
+        test("testTransience");
+
+        check(schema.isTransient("Foo")).eq(false);
+        schema.setTransient("Foo", true);
+        check(schema.isTransient("Foo")).eq(true);
+        schema.setTransient("Foo", false);
+        check(schema.isTransient("Foo")).eq(false);
+    }
+
+
+    //-------------------------------------------------------------------------
     // checkAndAdd(shape)
 
     // A shape is always accepted if the relation isn't previously known.

--- a/lib/src/test/java/com/wjduquette/joe/parser/NeroParserTest.java
+++ b/lib/src/test/java/com/wjduquette/joe/parser/NeroParserTest.java
@@ -78,6 +78,38 @@ public class NeroParserTest extends Ted {
             .eq("[line 1] error at ',', expected axiom or rule.");
     }
 
+    //-------------------------------------------------------------------------
+    // transientDeclaration
+
+    @Test public void testTransientDeclaration_expectedRelation() {
+        test("testTransientDeclaration_expectedRelation");
+
+        var source = """
+            transient 2;
+            """;
+        check(parseNero(source))
+            .eq("[line 1] error at '2', expected relation after 'transient'.");
+    }
+
+    @Test public void testTransientDeclaration_foundBuiltIn() {
+        test("testTransientDeclaration_foundBuiltIn");
+
+        var source = """
+            transient member;
+            """;
+        check(parseNero(source))
+            .eq("[line 1] error at 'member', found built-in predicate in 'transient' declaration.");
+    }
+
+    @Test public void testTransientDeclaration_expectedSemicolon() {
+        test("testDefineDeclaration_expectedSemicolon");
+
+        var source = """
+            transient Person:
+            """;
+        check(parseNero(source))
+            .eq("[line 1] error at ':', expected ';' after relation.");
+    }
 
     //-------------------------------------------------------------------------
     // defineDeclaration


### PR DESCRIPTION
This pull request adds the `transient` declaration and the `define transient` keyword to Nero rule sets.  A relation that is marked transient will be retained until inference is complete, and then dropped.  This can be used to drop existing relations from the input facts, as well as to drop intermediate results.