### PR TITLE
Nero Update Semantics

### DIFF
--- a/lib/src/main/java/com/wjduquette/joe/nero/NeroRuleSet.java
+++ b/lib/src/main/java/com/wjduquette/joe/nero/NeroRuleSet.java
@@ -1,8 +1,6 @@
 package com.wjduquette.joe.nero;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 /**
  * A collection of axioms and rules, ready for processing by the Nero engine.
@@ -64,5 +62,16 @@ public class NeroRuleSet {
 
     public Set<Rule> rules() {
         return Collections.unmodifiableSet(rules);
+    }
+
+    /**
+     * Gets a set of the names of all relations used in the rule set.
+     * @return The set
+     */
+    public Set<String> getRelations() {
+        var result = new HashSet<String>();
+        axioms.forEach(a -> result.add(a.relation()));
+        rules.forEach(r -> result.add(r.head().relation()));
+        return result;
     }
 }

--- a/lib/src/main/java/com/wjduquette/joe/nero/RuleEngine.java
+++ b/lib/src/main/java/com/wjduquette/joe/nero/RuleEngine.java
@@ -233,6 +233,18 @@ public class RuleEngine {
             knownFacts.drop(name);
             inferredFacts.drop(name);
         }
+
+        // NEXT, handle update semantics
+        for (var name : ruleset.getRelations()) {
+            if (!name.endsWith("!")) continue;
+
+            var oldName = name.substring(0, name.length() - 1);
+            knownFacts.drop(oldName);
+            knownFacts.rename(name, oldName);
+            inferredFacts.drop(oldName);
+            inferredFacts.rename(name, oldName);
+        }
+
     }
 
     private void inferStratum(int stratum, List<String> heads) {

--- a/lib/src/test/java/com/wjduquette/joe/nero/RuleEngineTest.java
+++ b/lib/src/test/java/com/wjduquette/joe/nero/RuleEngineTest.java
@@ -178,6 +178,9 @@ public class RuleEngineTest extends Ted {
             """);
     }
 
+    //-------------------------------------------------------------------------
+    // Transience
+
     @Test
     public void testTransient_transient_axiom() {
         test("testTransient_transient_axiom");
@@ -234,6 +237,33 @@ public class RuleEngineTest extends Ted {
         check(infer(source)).eq("""
             ListFact[relation=A, fields=[#a]]
             ListFact[relation=C, fields=[#a]]
+            """);
+    }
+
+    //-------------------------------------------------------------------------
+    // Updating Semantics
+
+    @Test public void testUpdating_axioms() {
+        test("testUpdating_axioms");
+        var source = """
+            A(#a);
+            A!(#b);
+            """;
+        check(infer(source)).eq("""
+            ListFact[relation=A, fields=[#b]]
+            """);
+    }
+
+    @Test public void testUpdating_rules() {
+        test("testUpdating_rules");
+        var source = """
+            A(#a, 5);
+            A(#b, 7);
+            A!(x) :- A(x, _);
+            """;
+        check(infer(source)).eq("""
+            ListFact[relation=A, fields=[#a]]
+            ListFact[relation=A, fields=[#b]]
             """);
     }
 

--- a/lib/src/test/java/com/wjduquette/joe/parser/NeroParserTest.java
+++ b/lib/src/test/java/com/wjduquette/joe/parser/NeroParserTest.java
@@ -255,6 +255,16 @@ public class NeroParserTest extends Ted {
     //-------------------------------------------------------------------------
     // rule()
 
+    @Test public void testRule_foundUpdateMarker() {
+        test("testRule_foundUpdateMarker");
+
+        var source = """
+            Thing(x) :- Bar!(x);
+            """;
+        check(parseNero(source))
+            .eq("[line 1] error at 'Bar', found update marker '!' in body atom of non-updating rule.");
+    }
+
     @Test public void testRule_negatedMember() {
         test("testRule_negatedMember");
 

--- a/lib/src/test/java/com/wjduquette/joe/parser/NeroParserTest.java
+++ b/lib/src/test/java/com/wjduquette/joe/parser/NeroParserTest.java
@@ -121,7 +121,7 @@ public class NeroParserTest extends Ted {
             define 2;
             """;
         check(parseNero(source))
-            .eq("[line 1] error at '2', expected relation after 'define'.");
+            .eq("[line 1] error at '2', expected relation after 'define [transient]'.");
     }
 
     @Test public void testDefineDeclaration_foundBuiltIn() {


### PR DESCRIPTION
This pull request adds update semantics to Nero, e.g.,
`A!(x, y) :- A(x), B(x, y);`.  When inference is complete, `A` is dropped and `A!` is renamed `A`.  

Non-updating rules cannot use `!` in body atoms, e.g.,
`B(x) :- A!(x, y);` is forbidden.  Use `B!(x)` instead.