### PR TITLE
`joe.test` API

### DIFF
--- a/lib/src/main/java/com/wjduquette/joe/tools/test/TestPackage.java
+++ b/lib/src/main/java/com/wjduquette/joe/tools/test/TestPackage.java
@@ -44,13 +44,14 @@ public class TestPackage extends JoePackage {
         super("joe.test");
         this.engine = engine;
 
-        globalFunction("assertEquals", this::_assertEquals);
+        globalFunction("assertEQ",     this::_assertEQ);
         globalFunction("assertError",  this::_assertError);
         globalFunction("assertFalse",  this::_assertFalse);
         globalFunction("assertTrue",   this::_assertTrue);
         globalFunction("engine",       this::_engine);
         globalFunction("fail",         this::_fail);
         globalFunction("skip",         this::_skip);
+        globalFunction("typedValue",   this::_typedValue);
 
         scriptResource(getClass(), "pkg.joe.test.joe");
 
@@ -59,19 +60,19 @@ public class TestPackage extends JoePackage {
     }
 
     //**
-    // @function assertEquals
+    // @function assertEQ
     // @args got, expected
     // Verifies that *got* equals the *expected* value, producing an
     // informative assertion error if not.
-    private Object _assertEquals(Joe joe, Args args) {
-        args.exactArity(2, "assertEquals(got, expected)");
+    private Object _assertEQ(Joe joe, Args args) {
+        args.exactArity(2, "assertEQ(got, expected)");
         var got      = args.next();
         var expected = args.next();
 
         if (!Joe.isEqual(got, expected)) {
             throw new AssertError(
-                "Computed: " + typedValue(joe, got) +
-                "\nExpected: " + typedValue(joe, expected));
+                "Computed: " + testValue(joe, got) +
+                "\nExpected: " + testValue(joe, expected));
         }
 
         return null;
@@ -200,10 +201,21 @@ public class TestPackage extends JoePackage {
         throw new TestTool.SkipError(joe.stringify(args.next()));
     }
 
+    //**
+    // @function typedValue
+    // @args value
+    // Outputs the value's type and value for display.  Collections are output in
+    // readable format.
+    private Object _typedValue(Joe joe, Args args) {
+        args.exactArity(1, "typedValue(value)");
+        return testValue(joe, args.next());
+    }
+
+
     //------------------------------------------------------------------------
     // Helpers
 
-    private String typedValue(Joe joe, Object value) {
+    private String testValue(Joe joe, Object value) {
         return switch (value) {
             case List<?> c -> typedList(joe, c);
             case Set<?> c -> typedSet(joe, c);

--- a/lib/src/main/java/com/wjduquette/joe/tools/test/TestPackage.java
+++ b/lib/src/main/java/com/wjduquette/joe/tools/test/TestPackage.java
@@ -46,8 +46,8 @@ public class TestPackage extends JoePackage {
 
         globalFunction("assertEQ",     this::_assertEQ);
         globalFunction("assertError",  this::_assertError);
-        globalFunction("assertFalse",  this::_assertFalse);
-        globalFunction("assertTrue",   this::_assertTrue);
+        globalFunction("assertF",  this::_assertF);
+        globalFunction("assertT",   this::_assertT);
         globalFunction("engine",       this::_engine);
         globalFunction("fail",         this::_fail);
         globalFunction("skip",         this::_skip);
@@ -138,12 +138,12 @@ public class TestPackage extends JoePackage {
     }
 
     //**
-    // @function assertFalse
+    // @function assertF
     // @args condition
     // Verifies that *condition* is falsey, producing an
     // informative assertion error if not.
-    private Object _assertFalse(Joe joe, Args args) {
-        args.exactArity(1, "assertFalse(condition)");
+    private Object _assertF(Joe joe, Args args) {
+        args.exactArity(1, "assertF(condition)");
         var condition = args.next();
 
         if (Joe.isTruthy(condition)) {
@@ -155,12 +155,12 @@ public class TestPackage extends JoePackage {
     }
 
     //**
-    // @function assertTrue
+    // @function assertT
     // @args condition
     // Verifies that *condition* is truthy, producing an
     // informative assertion error if not.
-    private Object _assertTrue(Joe joe, Args args) {
-        args.exactArity(1, "assertTrue(condition)");
+    private Object _assertT(Joe joe, Args args) {
+        args.exactArity(1, "assertT(condition)");
         var condition = args.next();
 
         if (!Joe.isTruthy(condition)) {

--- a/lib/src/main/java/com/wjduquette/joe/tools/test/TestTool.java
+++ b/lib/src/main/java/com/wjduquette/joe/tools/test/TestTool.java
@@ -193,10 +193,10 @@ public class TestTool implements Tool {
                 println("  SKIPPED: " + ex.getMessage());
                 ++skipCount;
             } catch (AssertError ex) {
-                println("  FAILED: " + ex.getJoeStackTrace());
+                println("  FAILED:\n" + ex.getJoeStackTrace().indent(4));
                 ++failureCount;
             } catch (JoeError ex) {
-                println("  ERROR: " + ex.getJoeStackTrace());
+                println("  ERROR:\n" + ex.getJoeStackTrace().indent(4));
                 ++errorCount;
             }
         }
@@ -232,8 +232,8 @@ public class TestTool implements Tool {
             }
 
             if (error != null) {
-                System.out.printf("%-8s %s %s, %s\n",
-                    result + ":", scriptPath, test, error.getMessage());
+                System.out.printf("%-8s %s %s\n%s\n", result + ":", scriptPath,
+                    test, error.getMessage().indent(4));
             }
         }
     }

--- a/lib/src/main/resources/com/wjduquette/joe/tools/test/pkg.joe.test.joe
+++ b/lib/src/main/resources/com/wjduquette/joe/tools/test/pkg.joe.test.joe
@@ -6,7 +6,7 @@
 //**
 // @function assertEmpty
 // @args value
-// @throws AssertError if the value is not empty.
+// Throws AssertError if the value is not empty, displaying the actual value.
 function assertEmpty(value) {
     if (!value.isEmpty()) {
         throw AssertError("Value is not empty:\nComputed: " + typedValue(value));

--- a/lib/src/main/resources/com/wjduquette/joe/tools/test/pkg.joe.test.joe
+++ b/lib/src/main/resources/com/wjduquette/joe/tools/test/pkg.joe.test.joe
@@ -4,6 +4,16 @@
 // @package joe.test
 
 //**
+// @function assertEmpty
+// @args value
+// @throws AssertError if the value is not empty.
+function assertEmpty(value) {
+    if (!value.isEmpty()) {
+        throw AssertError("Value is not empty:\nComputed: " + typedValue(value));
+    }
+}
+
+//**
 // @function check
 // @args value
 // @result ValueChecker

--- a/tests/lang_class.joe
+++ b/tests/lang_class.joe
@@ -117,7 +117,7 @@ function testInitializer() {
 function testToString_default() {
     class Thing {}
     var thing = Thing();
-    assertTrue(thing.toString().startsWith("<Thing"));
+    assertT(thing.toString().startsWith("<Thing"));
     assertEQ(Joe.stringify(thing), thing.toString());
 }
 

--- a/tests/lang_class.joe
+++ b/tests/lang_class.joe
@@ -8,14 +8,14 @@
 // Can declare a class
 function testDeclare() {
     class Thing {}
-    assertEquals(Joe.typeOf(Thing), Type);
+    assertEQ(Joe.typeOf(Thing), Type);
 }
 
 // Can create instances
 function testCreate() {
     class Thing {}
     var thing = Thing();
-    assertEquals(Joe.typeOf(thing), Thing);
+    assertEQ(Joe.typeOf(thing), Thing);
 }
 
 //-----------------------------------------------------------------------------
@@ -27,8 +27,8 @@ function testSetGetFields() {
     var thing = Thing();
     thing.name = "George";
     thing.color = #ginger;
-    assertEquals(thing.name, "George");
-    assertEquals(thing.color, #ginger);
+    assertEQ(thing.name, "George");
+    assertEQ(thing.color, #ginger);
 }
 
 //-----------------------------------------------------------------------------
@@ -39,7 +39,7 @@ function testDeclareMethod() {
     class Thing {
         method info() { return "I'm a Thing!"; }
     }
-    assertEquals(Thing().info(), "I'm a Thing!");
+    assertEQ(Thing().info(), "I'm a Thing!");
 }
 
 // Method arity is checked.
@@ -71,9 +71,9 @@ function testMethod_varargs_good() {
     }
     var thing = Thing();
 
-    assertEquals(thing.varArgs(#a), "#a,[]");
-    assertEquals(thing.varArgs(#a,#b), "#a,[#b]");
-    assertEquals(thing.varArgs(#a,#b,#c), "#a,[#b, #c]");
+    assertEQ(thing.varArgs(#a), "#a,[]");
+    assertEQ(thing.varArgs(#a,#b), "#a,[#b]");
+    assertEQ(thing.varArgs(#a,#b,#c), "#a,[#b, #c]");
 
     function bad() { thing.varArgs(); }
     assertError(bad,
@@ -90,7 +90,7 @@ function testMethodsCaptureScope() {
         }
     }
 
-    assertEquals(WithStatics().howdy(), #howdy);
+    assertEQ(WithStatics().howdy(), #howdy);
 }
 
 //-----------------------------------------------------------------------------
@@ -106,8 +106,8 @@ function testInitializer() {
     }
 
     var thing = Thing("Fred", #green);
-    assertEquals(thing.name, "Fred");
-    assertEquals(thing.color, #green);
+    assertEQ(thing.name, "Fred");
+    assertEQ(thing.color, #green);
 }
 
 //-----------------------------------------------------------------------------
@@ -118,7 +118,7 @@ function testToString_default() {
     class Thing {}
     var thing = Thing();
     assertTrue(thing.toString().startsWith("<Thing"));
-    assertEquals(Joe.stringify(thing), thing.toString());
+    assertEQ(Joe.stringify(thing), thing.toString());
 }
 
 // Custom toString()
@@ -127,8 +127,8 @@ function testToString_custom() {
         method toString() { return "I'm a Thing!"; }
     }
     var thing = Thing();
-    assertEquals(thing.toString(), "I'm a Thing!");
-    assertEquals(Joe.stringify(thing), thing.toString());
+    assertEQ(thing.toString(), "I'm a Thing!");
+    assertEQ(Joe.stringify(thing), thing.toString());
 }
 
 //-----------------------------------------------------------------------------
@@ -142,7 +142,7 @@ function testDeclareStaticMethod() {
         }
     }
 
-    assertEquals(WithStatics.greeting(), #howdy);
+    assertEQ(WithStatics.greeting(), #howdy);
 }
 
 // Static Methods can call each other.
@@ -156,7 +156,7 @@ function testStaticMethods() {
         }
     }
 
-    assertEquals(WithStatics.howdy(), #howdy);
+    assertEQ(WithStatics.howdy(), #howdy);
 }
 
 // Static methods can capture enclosing scope.
@@ -169,7 +169,7 @@ function testStaticMethodsCaptureScope() {
         }
     }
 
-    assertEquals(WithStatics.howdy(), #howdy);
+    assertEQ(WithStatics.howdy(), #howdy);
 }
 
 //-----------------------------------------------------------------------------
@@ -180,7 +180,7 @@ function testStaticFields() {
     class Thing {}
     Thing.greeting = #howdy;
 
-    assertEquals(Thing.greeting, #howdy);
+    assertEQ(Thing.greeting, #howdy);
 }
 
 // Methods can use static class fields
@@ -190,7 +190,7 @@ function testStaticFields_instanceMethods() {
     }
     Thing.greeting = #howdy;
 
-    assertEquals(Thing().howdy(), #howdy);
+    assertEQ(Thing().howdy(), #howdy);
 }
 
 // Static methods can use static class fields
@@ -200,7 +200,7 @@ function testStaticFields_staticMethods() {
     }
     Thing.greeting = #howdy;
 
-    assertEquals(Thing.howdy(), #howdy);
+    assertEQ(Thing.howdy(), #howdy);
 }
 
 //-----------------------------------------------------------------------------
@@ -214,7 +214,7 @@ function testStaticInitializer_initVars() {
         }
     }
 
-    assertEquals(Thing.greeting, #howdy);
+    assertEQ(Thing.greeting, #howdy);
 }
 
 // The static initializer can call static methods
@@ -226,7 +226,7 @@ function testStaticInitializer_initCallsStatics() {
         static method defaultGreeting() { return #howdy; }
     }
 
-    assertEquals(Thing.greeting, #howdy);
+    assertEQ(Thing.greeting, #howdy);
 }
 
 // The static initializer can create instances
@@ -237,7 +237,7 @@ function testStaticInitializer_initCallsStatics() {
         }
     }
 
-    assertEquals(Joe.typeOf(Thing.instance), Thing);
+    assertEQ(Joe.typeOf(Thing.instance), Thing);
 }
 
 // A class can have multiple static initializers
@@ -251,12 +251,12 @@ function testStaticInitializer_multiple() {
         method b() { return Thing.b; }
     }
 
-    assertEquals(Thing.a, 1);
-    assertEquals(Thing.b, 2);
+    assertEQ(Thing.a, 1);
+    assertEQ(Thing.b, 2);
 
     var thing = Thing();
-    assertEquals(thing.a(), 1);
-    assertEquals(thing.b(), 2);
+    assertEQ(thing.a(), 1);
+    assertEQ(thing.b(), 2);
 }
 
 //-----------------------------------------------------------------------------
@@ -273,8 +273,8 @@ function testSubclass_callParentMethod() {
     }
 
     var kid = Child();
-    assertEquals(kid.parent(), #parent);
-    assertEquals(kid.child(), #child);
+    assertEQ(kid.parent(), #parent);
+    assertEQ(kid.child(), #child);
 }
 
 // A subclass can override a superclass method
@@ -288,7 +288,7 @@ function testSubclass_overrideParentMethod() {
     }
 
     var kid = Child();
-    assertEquals(kid.parent(), #child);
+    assertEQ(kid.parent(), #child);
 }
 
 // A subclass will make use of the parent's init() if it doesn't define one
@@ -304,7 +304,7 @@ function testSubclass_parentInitializer() {
     }
 
     var kid = Child();
-    assertEquals(kid.getName(), "Parent");
+    assertEQ(kid.getName(), "Parent");
 }
 
 // A subclass will make use of the parent's init() if it doesn't define one.
@@ -318,7 +318,7 @@ function testSubclass_callSuper() {
         method getName() { return super.getName(); }
     }
     var kid = Child();
-    assertEquals(kid.getName(), #parent);
+    assertEQ(kid.getName(), #parent);
 }
 
 //-----------------------------------------------------------------------------
@@ -337,7 +337,7 @@ function testCanUseAt() {
         }
     }
     var thing = Thing("Fred", "red");
-    assertEquals(thing.info(), "name='Fred' color='red'");
+    assertEQ(thing.info(), "name='Fred' color='red'");
 }
 
 //-------------------------------------------------------------------------
@@ -355,7 +355,7 @@ function testThisInNestedFunction() {
         }
     }
 
-    assertEquals(Nest().whoAmI(), "Howard");
+    assertEQ(Nest().whoAmI(), "Howard");
 }
 
 // `.` is available in functions nested in methods
@@ -370,7 +370,7 @@ function testAtInNestedFunction() {
         }
     }
 
-    assertEquals(Nest().whoAmI(), "Howard");
+    assertEQ(Nest().whoAmI(), "Howard");
 }
 
 // `super` is available in functions nested in methods
@@ -387,7 +387,7 @@ function testSuperInNestedFunction() {
         }
     }
 
-    assertEquals(Child().name(), "*Howard*");
+    assertEQ(Child().name(), "*Howard*");
 }
 
 

--- a/tests/lang_for.joe
+++ b/tests/lang_for.joe
@@ -8,7 +8,7 @@ function testBasic() {
     for (var i = 1; i <= 3; i = i + 1) {
         sum = sum + i;
     }
-    assertEquals(sum, 6);
+    assertEQ(sum, 6);
 }
 
 function testNoInitializer() {
@@ -18,7 +18,7 @@ function testNoInitializer() {
     for (; i <= 3; i = i + 1) {
         sum = sum + i;
     }
-    assertEquals(sum, 6);
+    assertEQ(sum, 6);
 }
 
 function testNoUpdater() {
@@ -28,7 +28,7 @@ function testNoUpdater() {
         sum = sum + i;
         i = i + 1;
     }
-    assertEquals(sum, 6);
+    assertEQ(sum, 6);
 }
 
 
@@ -38,7 +38,7 @@ function testBreak() {
         sum = sum + i;
         if (i == 3) break;
     }
-    assertEquals(sum, 6);
+    assertEQ(sum, 6);
 }
 
 function testNoCondition() {
@@ -47,7 +47,7 @@ function testNoCondition() {
         sum = sum + i;
         if (i == 3) break;
     }
-    assertEquals(sum, 6);
+    assertEQ(sum, 6);
 }
 
 function testContinue() {
@@ -58,6 +58,6 @@ function testContinue() {
         if (i > 3) continue;
         sumAfter = sumAfter + i;
     }
-    assertEquals(sumBefore, 21);
-    assertEquals(sumAfter, 6);
+    assertEQ(sumBefore, 21);
+    assertEQ(sumAfter, 6);
 }

--- a/tests/lang_foreach.joe
+++ b/tests/lang_foreach.joe
@@ -13,7 +13,7 @@ function testForeach_simple() {
     foreach (i : list)
         result.add(i);
 
-    assertEquals(result, list);
+    assertEQ(result, list);
 }
 
 // Foreach loop with underscore variable
@@ -24,7 +24,7 @@ function testForeach_underscore() {
     foreach (_ : list)
         result.add(_);
 
-    assertEquals(result, list);
+    assertEQ(result, list);
 }
 
 
@@ -37,7 +37,7 @@ function testForeach_block() {
         result.add(i);
     }
 
-    assertEquals(result, list);
+    assertEQ(result, list);
 }
 
 // Basic foreach loop with break.
@@ -50,7 +50,7 @@ function testForeach_break() {
         result.add(i);
     }
 
-    assertEquals(result, ["a"]);
+    assertEQ(result, ["a"]);
 }
 
 // Basic foreach loop with continue
@@ -63,7 +63,7 @@ function testForeach_continue() {
         result.add(i);
     }
 
-    assertEquals(result, ["a", "c"]);
+    assertEQ(result, ["a", "c"]);
 }
 
 // Test that the foreach loop has its own scope.
@@ -88,9 +88,9 @@ function testBind_basic() {
         result.add(x.toString() + y);
     }
 
-    assertEquals(result, ["#a1", "#b2", "#c3"]);
-    assertEquals(x, "outer x");
-    assertEquals(y, "outer y");
+    assertEQ(result, ["#a1", "#b2", "#c3"]);
+    assertEQ(x, "outer x");
+    assertEQ(y, "outer y");
 }
 
 function testBind_break() {
@@ -102,7 +102,7 @@ function testBind_break() {
         result.add(x);
     }
 
-    assertEquals(result, [#a]);
+    assertEQ(result, [#a]);
 }
 
 function testBind_continue() {
@@ -114,7 +114,7 @@ function testBind_continue() {
         result.add(x);
     }
 
-    assertEquals(result, [#a, #c]);
+    assertEQ(result, [#a, #c]);
 }
 
 function testBind_hasOwnScope() {
@@ -137,14 +137,14 @@ function testBind_canInterpolate() {
     foreach ([x, $x] : list) {
         result = x;
     }
-    assertEquals(result, #b);
+    assertEQ(result, #b);
 }
 
 function testBind_canBindToItem() {
     var list = [[#a, 2]];
     foreach (a@[b, c] : list) {
-        assertEquals(a, [#a, 2]);
-        assertEquals(b, #a);
-        assertEquals(c, 2);
+        assertEQ(a, [#a, 2]);
+        assertEQ(b, #a);
+        assertEQ(c, 2);
     }
 }

--- a/tests/lang_function.joe
+++ b/tests/lang_function.joe
@@ -5,7 +5,7 @@
 // Can declare and call functions.
 function testDeclareFunction() {
     function info() { return "I'm a Thing!"; }
-    assertEquals(info(), "I'm a Thing!");
+    assertEQ(info(), "I'm a Thing!");
 }
 
 // Call something that's not callable.
@@ -18,7 +18,7 @@ function testNotCallable() {
 // Functions return null by default.
 function testReturnsNull() {
     function f() { }
-    assertEquals(f(), null);
+    assertEQ(f(), null);
 }
 
 // Function arity is checked.
@@ -43,9 +43,9 @@ function testFunction_varargs_good() {
         return first + "," + args;
     }
 
-    assertEquals(varArgs(#a), "#a,[]");
-    assertEquals(varArgs(#a,#b), "#a,[#b]");
-    assertEquals(varArgs(#a,#b,#c), "#a,[#b, #c]");
+    assertEQ(varArgs(#a), "#a,[]");
+    assertEQ(varArgs(#a,#b), "#a,[#b]");
+    assertEQ(varArgs(#a,#b,#c), "#a,[#b, #c]");
 
     function bad() { varArgs(); }
     assertError(bad,
@@ -57,7 +57,7 @@ function testFunctionsCaptureScope() {
     var greeting = #howdy;
     function howdy() { return greeting; }
 
-    assertEquals(howdy(), #howdy);
+    assertEQ(howdy(), #howdy);
 }
 
 //-----------------------------------------------------------------------------
@@ -65,20 +65,20 @@ function testFunctionsCaptureScope() {
 
 function testLambda_expr() {
     var f = \-> 5;
-    assertEquals(f(), 5);
+    assertEQ(f(), 5);
 
     var g = \x,y -> x + y;
-    assertEquals(g(2,3), 5);
+    assertEQ(g(2,3), 5);
 }
 
 function testLambda_block() {
     var f = \-> {
         return 5;
     };
-    assertEquals(f(), 5);
+    assertEQ(f(), 5);
 
     var g = \x,y -> {
         return x + y;
     };
-    assertEquals(g(2,3), 5);
+    assertEQ(g(2,3), 5);
 }

--- a/tests/lang_if.joe
+++ b/tests/lang_if.joe
@@ -9,8 +9,8 @@ function testIf() {
     if (true) a = #set;
     if (false) b = #set;
 
-    assertEquals(a, #set);
-    assertEquals(b, #unset);
+    assertEQ(a, #set);
+    assertEQ(b, #unset);
 }
 
 function testIfElse() {
@@ -21,8 +21,8 @@ function testIfElse() {
             return #false;
         }
     }
-    assertEquals(get(true), #true);
-    assertEquals(get(false), #false);
+    assertEQ(get(true), #true);
+    assertEQ(get(false), #false);
 }
 
 function testIfElseIfElse() {
@@ -35,7 +35,7 @@ function testIfElseIfElse() {
             return #c;
         }
     }
-    assertEquals(get(1), #a);
-    assertEquals(get(2), #b);
-    assertEquals(get(3), #c);
+    assertEQ(get(1), #a);
+    assertEQ(get(2), #b);
+    assertEQ(get(3), #c);
 }

--- a/tests/lang_list.joe
+++ b/tests/lang_list.joe
@@ -4,24 +4,24 @@ function testLiteral() {
     assertTrue([].isEmpty());
 
     var single = [#one];
-    assertEquals(single.size(), 1);
-    assertEquals(single.get(0), #one);
+    assertEQ(single.size(), 1);
+    assertEQ(single.get(0), #one);
 
     var double = [#one, #two];
-    assertEquals(double.size(), 2);
-    assertEquals(double.get(0), #one);
-    assertEquals(double.get(1), #two);
+    assertEQ(double.size(), 2);
+    assertEQ(double.get(0), #one);
+    assertEQ(double.get(1), #two);
 
     // Trailing comma is allowed in non-empty lists.
-    assertEquals([#one], [#one,]);
-    assertEquals([#one, #two], [#one, #two,]);
+    assertEQ([#one], [#one,]);
+    assertEQ([#one, #two], [#one, #two,]);
 }
 
 function testIndexing_get() {
     var list = [#a, #b, #c];
-    assertEquals(list[0], #a);
-    assertEquals(list[1], #b);
-    assertEquals(list[2], #c);
+    assertEQ(list[0], #a);
+    assertEQ(list[1], #b);
+    assertEQ(list[2], #c);
 
     assertError(\-> list["abc"],
         "Expected list index, got: String 'abc'.");
@@ -36,7 +36,7 @@ function testIndexing_equal() {
     list[0] = 1;
     list[1] = 2;
     list[2] = 3;
-    assertEquals(list, [1, 2, 3]);
+    assertEQ(list, [1, 2, 3]);
 
     assertError(\-> list["abc"] = 1,
         "Expected list index, got: String 'abc'.");
@@ -51,7 +51,7 @@ function testIndexing_plusEqual() {
     list[0] += 10;
     list[1] += 20;
     list[2] += 30;
-    assertEquals(list, [11, 22, 33]);
+    assertEQ(list, [11, 22, 33]);
 
     list[0] = "abc";
     assertError(\-> list[0] -= 1,
@@ -63,7 +63,7 @@ function testIndexing_minusEqual() {
     list[0] -= 1;
     list[1] -= 2;
     list[2] -= 3;
-    assertEquals(list, [9, 18, 27]);
+    assertEQ(list, [9, 18, 27]);
 }
 
 function testIndexing_starEqual() {
@@ -71,7 +71,7 @@ function testIndexing_starEqual() {
     list[0] *= 10;
     list[1] *= 20;
     list[2] *= 30;
-    assertEquals(list, [10, 40, 90]);
+    assertEQ(list, [10, 40, 90]);
 }
 
 function testIndexing_slashEqual() {
@@ -79,15 +79,15 @@ function testIndexing_slashEqual() {
     list[0] /= 5;
     list[1] /= 4;
     list[2] /= 3;
-    assertEquals(list, [2, 5, 10]);
+    assertEQ(list, [2, 5, 10]);
 }
 
 function testPrePost_plus() {
     var list = [1, 2, 3];
-    assertEquals(++list[0], 2);
-    assertEquals(list[0], 2);
-    assertEquals(list[0]++, 2);
-    assertEquals(list[0], 3);
+    assertEQ(++list[0], 2);
+    assertEQ(list[0], 2);
+    assertEQ(list[0]++, 2);
+    assertEQ(list[0], 3);
 
     list[0] = "abc";
 
@@ -99,10 +99,10 @@ function testPrePost_plus() {
 
 function testPrePost_minus() {
     var list = [10, 20, 30];
-    assertEquals(--list[0], 9);
-    assertEquals(list[0], 9);
-    assertEquals(list[0]--, 9);
-    assertEquals(list[0], 8);
+    assertEQ(--list[0], 9);
+    assertEQ(list[0], 9);
+    assertEQ(list[0]--, 9);
+    assertEQ(list[0], 8);
 
     list[0] = "abc";
 

--- a/tests/lang_list.joe
+++ b/tests/lang_list.joe
@@ -1,7 +1,7 @@
 // lang_list.joe: tests List-specific syntax.
 
 function testLiteral() {
-    assertTrue([].isEmpty());
+    assertT([].isEmpty());
 
     var single = [#one];
     assertEQ(single.size(), 1);

--- a/tests/lang_map.joe
+++ b/tests/lang_map.joe
@@ -3,26 +3,26 @@
 function testLiteral_empty() {
     var empty = {:};
     assertTrue(empty.isEmpty());
-    assertEquals(Joe.typeOf(empty), Map);
+    assertEQ(Joe.typeOf(empty), Map);
 }
 
 function testLiteral_noTrailingComma() {
     var map = {#a: 1, #b: 2};
-    assertEquals(map, Map.of(#a, 1, #b, 2));
-    assertEquals(map.get(#a), 1);
-    assertEquals(map.get(#b), 2);
+    assertEQ(map, Map.of(#a, 1, #b, 2));
+    assertEQ(map.get(#a), 1);
+    assertEQ(map.get(#b), 2);
 }
 
 function testLiteral_trailingComma() {
     // Trailing comma is allowed in non-empty maps
-    assertEquals({#a: 1,}, {#a: 1});
+    assertEQ({#a: 1,}, {#a: 1});
 }
 
 function testIndexing_get() {
     var map = {#a: 1, #b: 2, #c: 3};
-    assertEquals(map[#a], 1);
-    assertEquals(map[#b], 2);
-    assertEquals(map[#c], 3);
+    assertEQ(map[#a], 1);
+    assertEQ(map[#b], 2);
+    assertEQ(map[#c], 3);
 }
 
 function testIndexing_equal() {
@@ -31,7 +31,7 @@ function testIndexing_equal() {
     map[#b] = 4;
     map[#c] = 6;
 
-    assertEquals(map, {#a: 2, #b: 4, #c: 6});
+    assertEQ(map, {#a: 2, #b: 4, #c: 6});
 }
 
 function testIndexing_plusEqual() {
@@ -40,7 +40,7 @@ function testIndexing_plusEqual() {
     map[#b] += 4;
     map[#c] += 6;
 
-    assertEquals(map, {#a: 3, #b: 6, #c: 9});
+    assertEQ(map, {#a: 3, #b: 6, #c: 9});
 }
 
 function testIndexing_minusEqual() {
@@ -49,7 +49,7 @@ function testIndexing_minusEqual() {
     map[#b] -= 2;
     map[#c] -= 3;
 
-    assertEquals(map, {#a: 9, #b: 18, #c: 27});
+    assertEQ(map, {#a: 9, #b: 18, #c: 27});
 }
 
 function testIndexing_starEqual() {
@@ -58,7 +58,7 @@ function testIndexing_starEqual() {
     map[#b] *= 4;
     map[#c] *= 6;
 
-    assertEquals(map, {#a: 2, #b: 8, #c: 18});
+    assertEQ(map, {#a: 2, #b: 8, #c: 18});
 }
 
 function testIndexing_minusEqual() {
@@ -67,5 +67,5 @@ function testIndexing_minusEqual() {
     map[#b] /= 4;
     map[#c] /= 3;
 
-    assertEquals(map, {#a: 2, #b: 5, #c: 10});
+    assertEQ(map, {#a: 2, #b: 5, #c: 10});
 }

--- a/tests/lang_map.joe
+++ b/tests/lang_map.joe
@@ -2,7 +2,7 @@
 
 function testLiteral_empty() {
     var empty = {:};
-    assertTrue(empty.isEmpty());
+    assertT(empty.isEmpty());
     assertEQ(Joe.typeOf(empty), Map);
 }
 

--- a/tests/lang_match.joe
+++ b/tests/lang_match.joe
@@ -13,7 +13,7 @@ function testMatch_firstCase() {
         case [a, 2] -> result = a;
         default -> result = #fail;
     }
-    assertEquals(result, list[0]);
+    assertEQ(result, list[0]);
 }
 
 function testMatch_secondCase() {
@@ -24,7 +24,7 @@ function testMatch_secondCase() {
         case [1, b] -> result = b;
         default -> result = #fail;
     }
-    assertEquals(result, list[1]);
+    assertEQ(result, list[1]);
 }
 
 function testMatch_defaultCase() {
@@ -35,7 +35,7 @@ function testMatch_defaultCase() {
         case [2, 3] -> result = #fail;
         default -> result = #ok;
     }
-    assertEquals(result, #ok);
+    assertEQ(result, #ok);
 }
 
 function testMatch_noDefault() {
@@ -45,7 +45,7 @@ function testMatch_noDefault() {
     match (list) {
         case [2, 3] -> result = #fail;
     }
-    assertEquals(result, #ok);
+    assertEQ(result, #ok);
 }
 
 function testMatch_caseScope_success() {
@@ -57,8 +57,8 @@ function testMatch_caseScope_success() {
         case [a, 2] -> result = a;
         default -> result = #fail;
     }
-    assertEquals(result, list[0]);
-    assertEquals(a, "A");
+    assertEQ(result, list[0]);
+    assertEQ(a, "A");
 }
 
 function testMatch_caseScope_default() {
@@ -70,8 +70,8 @@ function testMatch_caseScope_default() {
         case [a, 2] -> result = a;
         default -> result = a;
     }
-    assertEquals(result, "A");
-    assertEquals(a, "A");
+    assertEQ(result, "A");
+    assertEQ(a, "A");
 }
 
 function testMatch_finalWildcard() {
@@ -83,7 +83,7 @@ function testMatch_finalWildcard() {
         case _ -> result = #ok;
         default -> result = #fail;
     }
-    assertEquals(result, #ok);
+    assertEQ(result, #ok);
 }
 
 function testVarTarget() {
@@ -95,7 +95,7 @@ function testVarTarget() {
         case {#b: b} -> { result = b; }
         default -> { result = "no match"; }
     }
-    assertEquals(result, 2);
+    assertEQ(result, 2);
 }
 
 function testInterpolatedConstant() {
@@ -108,7 +108,7 @@ function testInterpolatedConstant() {
         case {$tag: b} -> { result = b; }
         default -> { result = "no match"; }
     }
-    assertEquals(result, 2);
+    assertEQ(result, 2);
 }
 
 // Verify that a function can close over pattern variables.
@@ -122,13 +122,13 @@ function testMatch_WithClosures() {
     }
 
     var f1 = getFunc({#a: 1});
-    assertEquals(f1(), "a1");
+    assertEQ(f1(), "a1");
 
     var f2 = getFunc({#b: 2});
-    assertEquals(f2(), "b2");
+    assertEQ(f2(), "b2");
 
     var f3 = getFunc({#c: 3});
-    assertEquals(f3(), "no match");
+    assertEQ(f3(), "no match");
 }
 
 function testGuard() {
@@ -149,16 +149,16 @@ function testGuard() {
         default                -> { result = #d; }
     }
 
-    assertEquals(result, #c);
+    assertEQ(result, #c);
 }
 
 function testCanBindToItem() {
     var list = [#a, 2];
     match (list) {
         case a@[b, c] -> {
-            assertEquals(a, [#a, 2]);
-            assertEquals(b, #a);
-            assertEquals(c, 2);
+            assertEQ(a, [#a, 2]);
+            assertEQ(b, #a);
+            assertEQ(c, 2);
         }
         default -> fail("Didn't match target.");
     }

--- a/tests/lang_op.joe
+++ b/tests/lang_op.joe
@@ -42,43 +42,43 @@ function testDivide() {
 // Test Comparisons
 
 function testEquals() {
-    assertTrue(1 == 1);
-    assertTrue("a" == "a");
-    assertTrue(#k == #k);
-    assertFalse(1 == 2);
-    assertFalse("a" == #k);
+    assertT(1 == 1);
+    assertT("a" == "a");
+    assertT(#k == #k);
+    assertF(1 == 2);
+    assertF("a" == #k);
 }
 
 function testNotEquals() {
-    assertFalse(1 != 1);
-    assertTrue(1 != 2);
-    assertTrue("a" != #k);
+    assertF(1 != 1);
+    assertT(1 != 2);
+    assertT("a" != #k);
 }
 
 function testComparisons() {
-    assertTrue(0 < 1);
-    assertFalse(1 < 1);
-    assertTrue("a" < "b");
-    assertFalse("b" < "a");
+    assertT(0 < 1);
+    assertF(1 < 1);
+    assertT("a" < "b");
+    assertF("b" < "a");
 
-    assertTrue(0 <= 1);
-    assertTrue(1 <= 1);
-    assertFalse(2 <= 1);
-    assertTrue("a" <= "b");
-    assertTrue("a" <= "a");
-    assertFalse("b" <= "a");
+    assertT(0 <= 1);
+    assertT(1 <= 1);
+    assertF(2 <= 1);
+    assertT("a" <= "b");
+    assertT("a" <= "a");
+    assertF("b" <= "a");
 
-    assertFalse(0 > 0);
-    assertTrue(1 > 0);
-    assertFalse("a" > "a");
-    assertTrue("b" > "a");
+    assertF(0 > 0);
+    assertT(1 > 0);
+    assertF("a" > "a");
+    assertT("b" > "a");
 
-    assertTrue(1 >= 0);
-    assertTrue(1 >= 1);
-    assertFalse(1 >= 2);
-    assertTrue("b" >= "a");
-    assertTrue("b" >= "b");
-    assertFalse("b" >= "c");
+    assertT(1 >= 0);
+    assertT(1 >= 1);
+    assertF(1 >= 2);
+    assertT("b" >= "a");
+    assertT("b" >= "b");
+    assertF("b" >= "c");
 
     function bad() { "a" > 1; }
     assertError(bad, "The '>' operator expects two Numbers or two Strings.");
@@ -89,13 +89,13 @@ function testComparisons() {
 
 function testAnd() {
     // With booleans
-    assertTrue(true && true);
-    assertFalse(true && false);
-    assertFalse(false && true);
-    assertFalse(false && false);
+    assertT(true && true);
+    assertF(true && false);
+    assertF(false && true);
+    assertF(false && false);
 
     // Returns first argument if first is falsey.
-    assertFalse(false && 1);
+    assertF(false && 1);
     assertEQ(null && 1, null);
 
     // Returns second argument if first is truthy
@@ -105,13 +105,13 @@ function testAnd() {
 
 function testOr() {
     // With booleans
-    assertTrue(true || true);
-    assertTrue(true || false);
-    assertTrue(false || true);
-    assertFalse(false || false);
+    assertT(true || true);
+    assertT(true || false);
+    assertT(false || true);
+    assertF(false || false);
 
     // Returns first argument if first is truthy.
-    assertTrue(true || false);
+    assertT(true || false);
     assertEQ(1 || null, 1);
 
     // Returns second argument if first is falsy
@@ -120,10 +120,10 @@ function testOr() {
 }
 
 function testNot() {
-    assertFalse(!true);
-    assertFalse(!1);
-    assertTrue(!false);
-    assertTrue(!null);
+    assertF(!true);
+    assertF(!1);
+    assertT(!false);
+    assertT(!null);
 }
 
 //-----------------------------------------------------------------------------
@@ -348,8 +348,8 @@ function testTernary() {
 
 function testIN() {
     var list = [#a, #b, #c];
-    assertTrue(#a in list);
-    assertFalse(#d in list);
+    assertT(#a in list);
+    assertF(#d in list);
 
     function bad() { return #a in #a; }
     assertError(bad, "Expected iterable, got: Keyword '#a'.");
@@ -357,8 +357,8 @@ function testIN() {
 
 function testNI() {
     var list = [#a, #b, #c];
-    assertFalse(#a ni list);
-    assertTrue(#d ni list);
+    assertF(#a ni list);
+    assertT(#d ni list);
 
     function bad() { return #a ni #a; }
     assertError(bad, "Expected iterable, got: Keyword '#a'.");
@@ -371,27 +371,27 @@ function testNI() {
 
 function testMatchOp_simple() {
    var list = [1, 2];
-   assertTrue(list ~ [_, _]);
-   assertFalse(list ~ [_, _, _]);
+   assertT(list ~ [_, _]);
+   assertF(list ~ [_, _, _]);
 }
 
 function testMatchOp_bindOnSuccess() {
    var list = [1, 2];
-   assertTrue(list ~ [a, b]);
+   assertT(list ~ [a, b]);
    assertEQ(a, 1);
    assertEQ(b, 2);
 }
 
 function testMatchOp_bindWithAnd() {
    var list = [1, 2];
-   assertFalse(list ~ [a, b] && a > b);
+   assertF(list ~ [a, b] && a > b);
    assertEQ(a, 1);
    assertEQ(b, 2);
 }
 
 function testMatchOp_declareOnFailure() {
    var list = [1, 2, 3];
-   assertFalse(list ~ [a, b]);
+   assertF(list ~ [a, b]);
    assertEQ(a, null);
    assertEQ(b, null);
 }

--- a/tests/lang_op.joe
+++ b/tests/lang_op.joe
@@ -6,33 +6,33 @@
 // Arithmetic Operators
 
 function testPlus() {
-    assertEquals(1 + 2, 3);
-    assertEquals("a" + "b", "ab");
-    assertEquals("a" + 1, "a1");
-    assertEquals(1 + "a", "1a");
+    assertEQ(1 + 2, 3);
+    assertEQ("a" + "b", "ab");
+    assertEQ("a" + 1, "a1");
+    assertEQ(1 + "a", "1a");
 
     function bad() { #a + #b; }
     assertError(bad, "The '+' operator expects two Numbers or at least one String.");
 }
 
 function testMinus() {
-    assertEquals(4 - 1, 3);
-    assertEquals(1 - 4, -3);
+    assertEQ(4 - 1, 3);
+    assertEQ(1 - 4, -3);
 
     function bad() { 4 - "abc"; }
     assertError(bad, "The '-' operator expects two numeric operands.");
 }
 
 function testTimes() {
-    assertEquals(4 * 2, 8);
+    assertEQ(4 * 2, 8);
 
     function bad() { 4 * "abc"; }
     assertError(bad, "The '*' operator expects two numeric operands.");
 }
 
 function testDivide() {
-    assertEquals(4/2, 2);
-    assertEquals(String(4/0), "Infinity");  // TODO: support Infinity,  NaN
+    assertEQ(4/2, 2);
+    assertEQ(String(4/0), "Infinity");  // TODO: support Infinity,  NaN
 
     function bad() { 4 / "abc"; }
     assertError(bad, "The '/' operator expects two numeric operands.");
@@ -96,11 +96,11 @@ function testAnd() {
 
     // Returns first argument if first is falsey.
     assertFalse(false && 1);
-    assertEquals(null && 1, null);
+    assertEQ(null && 1, null);
 
     // Returns second argument if first is truthy
-    assertEquals(1 && 2, 2);
-    assertEquals(1 && null, null);
+    assertEQ(1 && 2, 2);
+    assertEQ(1 && null, null);
 }
 
 function testOr() {
@@ -112,11 +112,11 @@ function testOr() {
 
     // Returns first argument if first is truthy.
     assertTrue(true || false);
-    assertEquals(1 || null, 1);
+    assertEQ(1 || null, 1);
 
     // Returns second argument if first is falsy
-    assertEquals(false || 2, 2);
-    assertEquals(null || 4, 4);
+    assertEQ(false || 2, 2);
+    assertEQ(null || 4, 4);
 }
 
 function testNot() {
@@ -136,19 +136,19 @@ function testAssignment() {
     var b;
     var c;
     c = b = a;
-    assertEquals(a, 1);
-    assertEquals(b, 1);
-    assertEquals(c, 1);
+    assertEQ(a, 1);
+    assertEQ(b, 1);
+    assertEQ(c, 1);
 }
 
 function testPlusEquals_var() {
     var x = 5;
     var s = "abc";
-    assertEquals(x += 7, 12);
-    assertEquals(x, 12);
-    assertEquals(s += "def", "abcdef");
-    assertEquals(s, "abcdef");
-    assertEquals(x += "abc", "12abc");
+    assertEQ(x += 7, 12);
+    assertEQ(x, 12);
+    assertEQ(s += "def", "abcdef");
+    assertEQ(s, "abcdef");
+    assertEQ(x += "abc", "12abc");
 
     var y = 5;
     function bad1() { y += #abc; }
@@ -160,11 +160,11 @@ function testPlusEquals_property() {
     var thing = Thing();
     thing.x = 5;
     thing.s = "abc";
-    assertEquals(thing.x += 7, 12);
-    assertEquals(thing.x, 12);
-    assertEquals(thing.s += "def", "abcdef");
-    assertEquals(thing.s, "abcdef");
-    assertEquals(thing.x += "abc", "12abc");
+    assertEQ(thing.x += 7, 12);
+    assertEQ(thing.x, 12);
+    assertEQ(thing.s += "def", "abcdef");
+    assertEQ(thing.s, "abcdef");
+    assertEQ(thing.x += "abc", "12abc");
 
     thing.y = 5;
     function bad1() { thing.y += #abc; }
@@ -175,8 +175,8 @@ function testPlusEquals_property() {
 function testMinusEquals_var() {
     var x = 5;
     var s = "abc";
-    assertEquals(x -= 7, -2);
-    assertEquals(x, -2);
+    assertEQ(x -= 7, -2);
+    assertEQ(x, -2);
 
     function bad1() { x -= "abc"; }
     function bad2() { s -= 5; }
@@ -191,8 +191,8 @@ function testMinusEquals_property() {
     var thing = Thing();
     thing.x = 5;
     thing.s = "abc";
-    assertEquals(thing.x -= 7, -2);
-    assertEquals(thing.x, -2);
+    assertEQ(thing.x -= 7, -2);
+    assertEQ(thing.x, -2);
 
     function bad1() { thing.x -= "abc"; }
     function bad2() { thing.s -= 5; }
@@ -206,8 +206,8 @@ function testMinusEquals_property() {
 function testStarEquals_var() {
     var x = 5;
     var s = "abc";
-    assertEquals(x *= 7, 35);
-    assertEquals(x, 35);
+    assertEQ(x *= 7, 35);
+    assertEQ(x, 35);
 
     function bad1() { x *= "abc"; }
     function bad2() { s *= 5; }
@@ -222,8 +222,8 @@ function testStarEquals_property() {
     var thing = Thing();
     thing.x = 5;
     thing.s = "abc";
-    assertEquals(thing.x *= 7, 35);
-    assertEquals(thing.x, 35);
+    assertEQ(thing.x *= 7, 35);
+    assertEQ(thing.x, 35);
 
     function bad1() { thing.x *= "abc"; }
     function bad2() { thing.s *= 5; }
@@ -237,8 +237,8 @@ function testStarEquals_property() {
 function testSlashEquals_var() {
     var x = 50;
     var s = "abc";
-    assertEquals(x /= 5, 10);
-    assertEquals(x, 10);
+    assertEQ(x /= 5, 10);
+    assertEQ(x, 10);
 
     function bad1() { x /= "abc"; }
     function bad2() { s /= 5; }
@@ -253,8 +253,8 @@ function testSlashEquals_property() {
     var thing = Thing();
     thing.x = 50;
     thing.s = "abc";
-    assertEquals(thing.x /= 5, 10);
-    assertEquals(thing.x, 10);
+    assertEQ(thing.x /= 5, 10);
+    assertEQ(thing.x, 10);
 
     function bad1() { thing.x /= "abc"; }
     function bad2() { thing.s /= 5; }
@@ -272,28 +272,28 @@ function testSlashEquals_property() {
 
 function testPlusPlus_pre_var() {
     var x = 0;
-    assertEquals(++x, 1);
-    assertEquals(x, 1);
+    assertEQ(++x, 1);
+    assertEQ(x, 1);
 }
 
 function testPlusPlus_pre_prop() {
     var t = Thing();
     t.x = 0;
-    assertEquals(++t.x, 1);
-    assertEquals(t.x, 1);
+    assertEQ(++t.x, 1);
+    assertEQ(t.x, 1);
 }
 
 function testPlusPlus_post_var() {
     var x = 0;
-    assertEquals(x++, 0);
-    assertEquals(x, 1);
+    assertEQ(x++, 0);
+    assertEQ(x, 1);
 }
 
 function testPlusPlus_post_prop() {
     var t = Thing();
     t.x = 0;
-    assertEquals(t.x++, 0);
-    assertEquals(t.x, 1);
+    assertEQ(t.x++, 0);
+    assertEQ(t.x, 1);
 }
 
 function testPlusPlus_nonNumber() {
@@ -304,28 +304,28 @@ function testPlusPlus_nonNumber() {
 
 function testMinusMinus_pre_var() {
     var x = 0;
-    assertEquals(--x, -1);
-    assertEquals(x, -1);
+    assertEQ(--x, -1);
+    assertEQ(x, -1);
 }
 
 function testMinusMinus_pre_prop() {
     var t = Thing();
     t.x = 0;
-    assertEquals(--t.x, -1);
-    assertEquals(t.x, -1);
+    assertEQ(--t.x, -1);
+    assertEQ(t.x, -1);
 }
 
 function testMinusMinus_post_var() {
     var x = 0;
-    assertEquals(x--, 0);
-    assertEquals(x, -1);
+    assertEQ(x--, 0);
+    assertEQ(x, -1);
 }
 
 function testMinusMinus_post_prop() {
     var t = Thing();
     t.x = 0;
-    assertEquals(t.x--, 0);
-    assertEquals(t.x, -1);
+    assertEQ(t.x--, 0);
+    assertEQ(t.x, -1);
 }
 
 function testMinusMinus_nonNumber() {
@@ -339,8 +339,8 @@ function testMinusMinus_nonNumber() {
 // Ternary Operator
 
 function testTernary() {
-    assertEquals(true ? "a" : "b", "a");
-    assertEquals(false ? "a" : "b", "b");
+    assertEQ(true ? "a" : "b", "a");
+    assertEQ(false ? "a" : "b", "b");
 }
 
 //-----------------------------------------------------------------------------
@@ -378,22 +378,22 @@ function testMatchOp_simple() {
 function testMatchOp_bindOnSuccess() {
    var list = [1, 2];
    assertTrue(list ~ [a, b]);
-   assertEquals(a, 1);
-   assertEquals(b, 2);
+   assertEQ(a, 1);
+   assertEQ(b, 2);
 }
 
 function testMatchOp_bindWithAnd() {
    var list = [1, 2];
    assertFalse(list ~ [a, b] && a > b);
-   assertEquals(a, 1);
-   assertEquals(b, 2);
+   assertEQ(a, 1);
+   assertEQ(b, 2);
 }
 
 function testMatchOp_declareOnFailure() {
    var list = [1, 2, 3];
    assertFalse(list ~ [a, b]);
-   assertEquals(a, null);
-   assertEquals(b, null);
+   assertEQ(a, null);
+   assertEQ(b, null);
 }
 
 // Verify that having working values on the stack
@@ -401,9 +401,9 @@ function testMatchOp_declareOnFailure() {
 function testMatchOp_withWorkingStack() {
    var list = [1, 2];
    var value = "(" + (list ~ [a, b]) + ")";
-   assertEquals(value, "(true)");
-   assertEquals(a, 1);
-   assertEquals(b, 2);
+   assertEQ(value, "(true)");
+   assertEQ(a, 1);
+   assertEQ(b, 2);
 }
 
 //-----------------------------------------------------------------------------

--- a/tests/lang_pattern.joe
+++ b/tests/lang_pattern.joe
@@ -10,14 +10,14 @@
 // Verify that a binding variable matches anything.
 function testOneVar() {
     assertTrue(1 ~ a);
-    assertEquals(a, 1);
+    assertEQ(a, 1);
 }
 
 // Verify that a wildcard matches anything, and doesn't create a binding.
 function testWildcard() {
     var _ = 5;
     assertTrue(1 ~ _);
-    assertEquals(_, 5);
+    assertEQ(_, 5);
 }
 
 // Verify that a literal constant only matches the same value.
@@ -49,30 +49,30 @@ function testList_noMatch() {
 
 function testList_noTail() {
     assertTrue([1, 2] ~ [a, b]);
-    assertEquals(a, 1);
-    assertEquals(b, 2);
+    assertEQ(a, 1);
+    assertEQ(b, 2);
 }
 
 function testList_emptyTail() {
     assertTrue([1, 2] ~ [a, b : c]);
-    assertEquals(a, 1);
-    assertEquals(b, 2);
-    assertEquals(c, []);
+    assertEQ(a, 1);
+    assertEQ(b, 2);
+    assertEQ(c, []);
 }
 
 function testList_fullTail() {
     assertTrue([1, 2, 3, 4] ~ [a, b : c]);
-    assertEquals(a, 1);
-    assertEquals(b, 2);
-    assertEquals(c, [3, 4]);
+    assertEQ(a, 1);
+    assertEQ(b, 2);
+    assertEQ(c, [3, 4]);
 }
 
 function testList_nestedPattern() {
     assertTrue([1, [2, 3], 4] ~ [a, [b, c], d]);
-    assertEquals(a, 1);
-    assertEquals(b, 2);
-    assertEquals(c, 3);
-    assertEquals(d, 4);
+    assertEQ(a, 1);
+    assertEQ(b, 2);
+    assertEQ(c, 3);
+    assertEQ(d, 4);
 }
 
 //-------------------------------------------------------------------------
@@ -101,14 +101,14 @@ function testMap_valueMismatch() {
 // The pattern matches.
 function testMap_good() {
     assertTrue({"abc": 5, "def": 6} ~ {"abc": a});
-    assertEquals(a, 5);
+    assertEQ(a, 5);
 }
 
 // Map keys can be interpolated into the pattern.
 function testMap_interpolatedKey() {
     var key = #joe;
     assertTrue({#joe: #value} ~ {$key: value});
-    assertEquals(value, #value);
+    assertEQ(value, #value);
 }
 
 //-----------------------------------------------------------------------------
@@ -138,8 +138,8 @@ function testNamedField_good() {
     var thing = Thing(123, "red");
 
     assertTrue(thing ~ Thing(id: i, color: c));
-    assertEquals(i, thing.id);
-    assertEquals(c, thing.color);
+    assertEQ(i, thing.id);
+    assertEQ(c, thing.color);
 }
 
 // Can match if the pattern names a supertype of the value.
@@ -147,16 +147,16 @@ function testNamedField_supertype_good() {
     var gizmo = Gizmo(123, "red");
 
     assertTrue(gizmo ~ Thing(id: i, color: c));
-    assertEquals(i, gizmo.id);
-    assertEquals(c, gizmo.color);
+    assertEQ(i, gizmo.id);
+    assertEQ(c, gizmo.color);
 }
 
 // Can match a Fact by its relation
 function testNamedField_fact() {
     var person = Fact("Person", "Joe", 80);
     assertTrue(person ~ Person(f0: name, f1: age));
-    assertEquals(name, person.f0);
-    assertEquals(age, person.f1);
+    assertEQ(name, person.f0);
+    assertEQ(age, person.f1);
 }
 
 //-----------------------------------------------------------------------------
@@ -179,16 +179,16 @@ function testOrderedField_good() {
     var person = Person("Joe", 80);
 
     assertTrue(person ~ Person(name, age));
-    assertEquals(name, person.name);
-    assertEquals(age, person.age);
+    assertEQ(name, person.name);
+    assertEQ(age, person.age);
 }
 
 // Can match a Fact by its relation provided that it has ordered fields.
 function testOrderedField_fact() {
     var person = Fact("Person", "Joe", 80);
     assertTrue(person ~ Person(name, age));
-    assertEquals(name, person.f0);
-    assertEquals(age, person.f1);
+    assertEQ(name, person.f0);
+    assertEQ(age, person.f1);
 }
 
 
@@ -197,18 +197,18 @@ function testOrderedField_fact() {
 
 function testPatternBinding_atTop() {
     assertTrue([1, 2] ~ a@[b, c]);
-    assertEquals(a, [1, 2]);
-    assertEquals(b, 1);
-    assertEquals(c, 2);
+    assertEQ(a, [1, 2]);
+    assertEQ(b, 1);
+    assertEQ(c, 2);
 }
 
 function testPatternBinding_nested() {
     assertTrue([1, [2, 3], 4] ~ [a, b@[c, d], e]);
-    assertEquals(a, 1);
-    assertEquals(b, [2, 3]);
-    assertEquals(c, 2);
-    assertEquals(d, 3);
-    assertEquals(e, 4);
+    assertEQ(a, 1);
+    assertEQ(b, [2, 3]);
+    assertEQ(c, 2);
+    assertEQ(d, 3);
+    assertEQ(e, 4);
 }
 
 //-----------------------------------------------------------------------------

--- a/tests/lang_pattern.joe
+++ b/tests/lang_pattern.joe
@@ -9,66 +9,66 @@
 
 // Verify that a binding variable matches anything.
 function testOneVar() {
-    assertTrue(1 ~ a);
+    assertT(1 ~ a);
     assertEQ(a, 1);
 }
 
 // Verify that a wildcard matches anything, and doesn't create a binding.
 function testWildcard() {
     var _ = 5;
-    assertTrue(1 ~ _);
+    assertT(1 ~ _);
     assertEQ(_, 5);
 }
 
 // Verify that a literal constant only matches the same value.
 function testLiteralConstant() {
-    assertTrue(1 ~ 1);
-    assertFalse(1 ~ 2);
+    assertT(1 ~ 1);
+    assertF(1 ~ 2);
 }
 
 // Verify that an interpolated variable yields a constant.
 function testInterpolatedVariable() {
     var x = 1;
     var y = 2;
-    assertTrue(1 ~ $x);
-    assertFalse(1 ~ $y);
+    assertT(1 ~ $x);
+    assertF(1 ~ $y);
 }
 
 // Verify that an interpolated expression yields a constant.
 function testInterpolatedExpression() {
-    assertTrue(2 ~ $(1 + 1));
-    assertFalse(1 ~ $(1 + 1));
+    assertT(2 ~ $(1 + 1));
+    assertF(1 ~ $(1 + 1));
 }
 
 //-------------------------------------------------------------------------
 // List Patterns
 
 function testList_noMatch() {
-    assertFalse(5 ~ [1, 2]);
+    assertF(5 ~ [1, 2]);
 }
 
 function testList_noTail() {
-    assertTrue([1, 2] ~ [a, b]);
+    assertT([1, 2] ~ [a, b]);
     assertEQ(a, 1);
     assertEQ(b, 2);
 }
 
 function testList_emptyTail() {
-    assertTrue([1, 2] ~ [a, b : c]);
+    assertT([1, 2] ~ [a, b : c]);
     assertEQ(a, 1);
     assertEQ(b, 2);
     assertEQ(c, []);
 }
 
 function testList_fullTail() {
-    assertTrue([1, 2, 3, 4] ~ [a, b : c]);
+    assertT([1, 2, 3, 4] ~ [a, b : c]);
     assertEQ(a, 1);
     assertEQ(b, 2);
     assertEQ(c, [3, 4]);
 }
 
 function testList_nestedPattern() {
-    assertTrue([1, [2, 3], 4] ~ [a, [b, c], d]);
+    assertT([1, [2, 3], 4] ~ [a, [b, c], d]);
     assertEQ(a, 1);
     assertEQ(b, 2);
     assertEQ(c, 3);
@@ -80,34 +80,34 @@ function testList_nestedPattern() {
 
 function testMap_matchEmptyMap() {
     // The {} pattern should be "{:}".
-    assertTrue({:} ~ {:});
+    assertT({:} ~ {:});
 }
 
 // Value isn't a map
 function testMap_noMap() {
-    assertFalse(5 ~ {#abc: a});
+    assertF(5 ~ {#abc: a});
 }
 
 // Value is a map, but is missing a key that appears in the pattern.
 function testMap_missingKey() {
-    assertFalse({#def: 5} ~ {#abc: a});
+    assertF({#def: 5} ~ {#abc: a});
 }
 
 // Value has the right keys, but one of the values is wrong.
 function testMap_valueMismatch() {
-    assertFalse({#abc: 5, #def: 6} ~ {#abc: a, #def: 7});
+    assertF({#abc: 5, #def: 6} ~ {#abc: a, #def: 7});
 }
 
 // The pattern matches.
 function testMap_good() {
-    assertTrue({"abc": 5, "def": 6} ~ {"abc": a});
+    assertT({"abc": 5, "def": 6} ~ {"abc": a});
     assertEQ(a, 5);
 }
 
 // Map keys can be interpolated into the pattern.
 function testMap_interpolatedKey() {
     var key = #joe;
-    assertTrue({#joe: #value} ~ {$key: value});
+    assertT({#joe: #value} ~ {$key: value});
     assertEQ(value, #value);
 }
 
@@ -116,28 +116,28 @@ function testMap_interpolatedKey() {
 
 // Can't match a value that has no script-visible fields.
 function testNamedField_noFields() {
-    assertFalse("abc" ~ Thing(id: id));
+    assertF("abc" ~ Thing(id: id));
 }
 
 // Can't match a value of the different type.
 function testNamedField_valueWrongType() {
     var thing = Thing(123, "red");
 
-    assertFalse(thing ~ Gizmo(id: id));
+    assertF(thing ~ Gizmo(id: id));
 }
 
 // Can't match if a pattern field doesn't exist in the value.
 function testNamedField_unknownField() {
     var thing = Thing(123, "red");
 
-    assertFalse(thing ~ Thing(id: id, style: s));
+    assertF(thing ~ Thing(id: id, style: s));
 }
 
 // Can match if the type name and the field names match.
 function testNamedField_good() {
     var thing = Thing(123, "red");
 
-    assertTrue(thing ~ Thing(id: i, color: c));
+    assertT(thing ~ Thing(id: i, color: c));
     assertEQ(i, thing.id);
     assertEQ(c, thing.color);
 }
@@ -146,7 +146,7 @@ function testNamedField_good() {
 function testNamedField_supertype_good() {
     var gizmo = Gizmo(123, "red");
 
-    assertTrue(gizmo ~ Thing(id: i, color: c));
+    assertT(gizmo ~ Thing(id: i, color: c));
     assertEQ(i, gizmo.id);
     assertEQ(c, gizmo.color);
 }
@@ -154,7 +154,7 @@ function testNamedField_supertype_good() {
 // Can match a Fact by its relation
 function testNamedField_fact() {
     var person = Fact("Person", "Joe", 80);
-    assertTrue(person ~ Person(f0: name, f1: age));
+    assertT(person ~ Person(f0: name, f1: age));
     assertEQ(name, person.f0);
     assertEQ(age, person.f1);
 }
@@ -164,21 +164,21 @@ function testNamedField_fact() {
 
 // Can't match a value with unordered fields
 function testOrderedField_notOrdered() {
-    assertFalse(Thing(123, "red") ~ Thing(id, color));
+    assertF(Thing(123, "red") ~ Thing(id, color));
 }
 
 // Can't match if the type is wrong.
 function testOrderedField_wrongType() {
     var person = Person("Joe", 80);
 
-    assertFalse(person ~ PersonNonGrata(name, age));
+    assertF(person ~ PersonNonGrata(name, age));
 }
 
 // Can match if the number of fields is correct.
 function testOrderedField_good() {
     var person = Person("Joe", 80);
 
-    assertTrue(person ~ Person(name, age));
+    assertT(person ~ Person(name, age));
     assertEQ(name, person.name);
     assertEQ(age, person.age);
 }
@@ -186,7 +186,7 @@ function testOrderedField_good() {
 // Can match a Fact by its relation provided that it has ordered fields.
 function testOrderedField_fact() {
     var person = Fact("Person", "Joe", 80);
-    assertTrue(person ~ Person(name, age));
+    assertT(person ~ Person(name, age));
     assertEQ(name, person.f0);
     assertEQ(age, person.f1);
 }
@@ -196,14 +196,14 @@ function testOrderedField_fact() {
 // Pattern-Bindings
 
 function testPatternBinding_atTop() {
-    assertTrue([1, 2] ~ a@[b, c]);
+    assertT([1, 2] ~ a@[b, c]);
     assertEQ(a, [1, 2]);
     assertEQ(b, 1);
     assertEQ(c, 2);
 }
 
 function testPatternBinding_nested() {
-    assertTrue([1, [2, 3], 4] ~ [a, b@[c, d], e]);
+    assertT([1, [2, 3], 4] ~ [a, b@[c, d], e]);
     assertEQ(a, 1);
     assertEQ(b, [2, 3]);
     assertEQ(c, 2);
@@ -218,10 +218,10 @@ function testPatternBinding_nested() {
 function testTypeName() {
     record Gizmo(x, y) {}
     var gizmo = Gizmo(1, 2);
-    assertTrue(gizmo ~ Gizmo());
-    assertFalse(gizmo ~ Number());
-    assertTrue("abc" ~ String());
-    assertFalse("abc" ~ Number());
+    assertT(gizmo ~ Gizmo());
+    assertF(gizmo ~ Number());
+    assertT("abc" ~ String());
+    assertF("abc" ~ Number());
 }
 
 //-----------------------------------------------------------------------------

--- a/tests/lang_record.joe
+++ b/tests/lang_record.joe
@@ -8,14 +8,14 @@
 // Can declare a record
 function testDeclare() {
     record Thing(id, color) {}
-    assertEquals(Joe.typeOf(Thing), Type);
+    assertEQ(Joe.typeOf(Thing), Type);
 }
 
 // Can create instances
 function testCreate() {
     record Thing(id, color) {}
     var thing = Thing(123, #red);
-    assertEquals(Joe.typeOf(thing), Thing);
+    assertEQ(Joe.typeOf(thing), Thing);
 }
 
 // Creation arity is checked.
@@ -34,8 +34,8 @@ function testCreate_arity() {
 function testGetFields() {
     record Thing(id, color) {}
     var thing = Thing(123, #red);
-    assertEquals(thing.id, 123);
-    assertEquals(thing.color, #red);
+    assertEQ(thing.id, 123);
+    assertEQ(thing.color, #red);
 }
 
 //-----------------------------------------------------------------------------
@@ -46,7 +46,7 @@ function testDeclareMethod() {
     record Thing(id, color) {
         method info() { return "I'm a Thing!"; }
     }
-    assertEquals(Thing(123, #red).info(), "I'm a Thing!");
+    assertEQ(Thing(123, #red).info(), "I'm a Thing!");
 }
 
 // Method arity is checked.
@@ -78,9 +78,9 @@ function testMethod_varargs_good() {
     }
     var thing = Thing(123);
 
-    assertEquals(thing.varArgs(#a), "#a,[]");
-    assertEquals(thing.varArgs(#a,#b), "#a,[#b]");
-    assertEquals(thing.varArgs(#a,#b,#c), "#a,[#b, #c]");
+    assertEQ(thing.varArgs(#a), "#a,[]");
+    assertEQ(thing.varArgs(#a,#b), "#a,[#b]");
+    assertEQ(thing.varArgs(#a,#b,#c), "#a,[#b, #c]");
 
     function bad() { thing.varArgs(); }
     assertError(bad,
@@ -97,7 +97,7 @@ function testMethodsCaptureScope() {
         }
     }
 
-    assertEquals(WithStatics(123).howdy(), #howdy);
+    assertEQ(WithStatics(123).howdy(), #howdy);
 }
 
 //-----------------------------------------------------------------------------
@@ -107,8 +107,8 @@ function testMethodsCaptureScope() {
 function testToString_default() {
     record Thing(id, color) {}
     var thing = Thing(123, #red);
-    assertEquals(thing.toString(), "Thing(123, #red)");
-    assertEquals(Joe.stringify(thing), thing.toString());
+    assertEQ(thing.toString(), "Thing(123, #red)");
+    assertEQ(Joe.stringify(thing), thing.toString());
 }
 
 // Custom toString()
@@ -117,8 +117,8 @@ function testToString_custom() {
         method toString() { return "I'm a Thing!"; }
     }
     var thing = Thing(123);
-    assertEquals(thing.toString(), "I'm a Thing!");
-    assertEquals(Joe.stringify(thing), thing.toString());
+    assertEQ(thing.toString(), "I'm a Thing!");
+    assertEQ(Joe.stringify(thing), thing.toString());
 }
 
 //-----------------------------------------------------------------------------
@@ -132,7 +132,7 @@ function testDeclareStaticMethod() {
         }
     }
 
-    assertEquals(WithStatics.greeting(), #howdy);
+    assertEQ(WithStatics.greeting(), #howdy);
 }
 
 // Static Methods can call each other.
@@ -146,7 +146,7 @@ function testStaticMethods() {
         }
     }
 
-    assertEquals(WithStatics.howdy(), #howdy);
+    assertEQ(WithStatics.howdy(), #howdy);
 }
 
 // Static methods can capture enclosing scope.
@@ -159,7 +159,7 @@ function testStaticMethodsCaptureScope() {
         }
     }
 
-    assertEquals(WithStatics.howdy(), #howdy);
+    assertEQ(WithStatics.howdy(), #howdy);
 }
 
 //-----------------------------------------------------------------------------
@@ -170,7 +170,7 @@ function testStaticFields() {
     record Thing(id) {}
     Thing.greeting = #howdy;
 
-    assertEquals(Thing.greeting, #howdy);
+    assertEQ(Thing.greeting, #howdy);
 }
 
 // Methods can use static record fields
@@ -180,7 +180,7 @@ function testStaticFields_instanceMethods() {
     }
     Thing.greeting = #howdy;
 
-    assertEquals(Thing(123).howdy(), #howdy);
+    assertEQ(Thing(123).howdy(), #howdy);
 }
 
 // Static methods can use static record fields
@@ -190,7 +190,7 @@ function testStaticFields_staticMethods() {
     }
     Thing.greeting = #howdy;
 
-    assertEquals(Thing.howdy(), #howdy);
+    assertEQ(Thing.howdy(), #howdy);
 }
 
 //-----------------------------------------------------------------------------
@@ -204,7 +204,7 @@ function testStaticInitializer_initVars() {
         }
     }
 
-    assertEquals(Thing.greeting, #howdy);
+    assertEQ(Thing.greeting, #howdy);
 }
 
 // The static initializer can call static methods
@@ -216,7 +216,7 @@ function testStaticInitializer_initCallsStatics() {
         static method defaultGreeting() { return #howdy; }
     }
 
-    assertEquals(Thing.greeting, #howdy);
+    assertEQ(Thing.greeting, #howdy);
 }
 
 // The static initializer can create instances
@@ -227,7 +227,7 @@ function testStaticInitializer_initCreates() {
         }
     }
 
-    assertEquals(Joe.typeOf(Thing.instance), Thing);
+    assertEQ(Joe.typeOf(Thing.instance), Thing);
 }
 
 // A record can have multiple static initializers
@@ -241,12 +241,12 @@ function testStaticInitializer_multiple() {
         method b() { return Thing.b; }
     }
 
-    assertEquals(Thing.a, 1);
-    assertEquals(Thing.b, 2);
+    assertEQ(Thing.a, 1);
+    assertEQ(Thing.b, 2);
 
     var thing = Thing(123);
-    assertEquals(thing.a(), 1);
-    assertEquals(thing.b(), 2);
+    assertEQ(thing.a(), 1);
+    assertEQ(thing.b(), 2);
 }
 
 //-----------------------------------------------------------------------------
@@ -260,7 +260,7 @@ function testCanUseAt() {
         }
     }
     var thing = Thing("Fred", "red");
-    assertEquals(thing.info(), "name='Fred' color='red'");
+    assertEQ(thing.info(), "name='Fred' color='red'");
 }
 
 //-------------------------------------------------------------------------
@@ -277,7 +277,7 @@ function testThisInNestedFunction() {
         }
     }
 
-    assertEquals(Nest("Howard").whoAmI(), "Howard");
+    assertEQ(Nest("Howard").whoAmI(), "Howard");
 }
 
 // `.` is available in functions nested in methods
@@ -291,7 +291,7 @@ function testAtInNestedFunction() {
         }
     }
 
-    assertEquals(Nest("Howard").whoAmI(), "Howard");
+    assertEQ(Nest("Howard").whoAmI(), "Howard");
 }
 
 

--- a/tests/lang_set.joe
+++ b/tests/lang_set.joe
@@ -3,15 +3,15 @@
 function testLiteral_empty() {
     var empty = {};
     assertTrue(empty.isEmpty());
-    assertEquals(Joe.typeOf(empty), Set);
+    assertEQ(Joe.typeOf(empty), Set);
 }
 
 function testLiteral_noTrailingComma() {
     var set = {#a, #b, #c, #a};
-    assertEquals(set, Set.of(#a, #b, #c));
+    assertEQ(set, Set.of(#a, #b, #c));
 }
 
 function testLiteral_trailingComma() {
     var set = {#a, #b, #c, #a, };
-    assertEquals(set, Set.of(#a, #b, #c));
+    assertEQ(set, Set.of(#a, #b, #c));
 }

--- a/tests/lang_set.joe
+++ b/tests/lang_set.joe
@@ -2,7 +2,7 @@
 
 function testLiteral_empty() {
     var empty = {};
-    assertTrue(empty.isEmpty());
+    assertT(empty.isEmpty());
     assertEQ(Joe.typeOf(empty), Set);
 }
 

--- a/tests/lang_switch.joe
+++ b/tests/lang_switch.joe
@@ -10,10 +10,10 @@ function testSimple() {
         }
     }
 
-    assertEquals(cases(1), "a");
-    assertEquals(cases(2), "b");
-    assertEquals(cases(3), "c");
-    assertEquals(cases(4), "?");
+    assertEQ(cases(1), "a");
+    assertEQ(cases(2), "b");
+    assertEQ(cases(3), "c");
+    assertEQ(cases(4), "?");
 }
 
 function testMulti() {
@@ -26,16 +26,16 @@ function testMulti() {
         }
     }
 
-    assertEquals(cases(1), "abc");
-    assertEquals(cases(2), "abc");
-    assertEquals(cases(3), "abc");
-    assertEquals(cases(4), "def");
-    assertEquals(cases(5), "def");
-    assertEquals(cases(6), "def");
-    assertEquals(cases(7), "ghi");
-    assertEquals(cases(8), "ghi");
-    assertEquals(cases(9), "ghi");
-    assertEquals(cases(0), "?");
+    assertEQ(cases(1), "abc");
+    assertEQ(cases(2), "abc");
+    assertEQ(cases(3), "abc");
+    assertEQ(cases(4), "def");
+    assertEQ(cases(5), "def");
+    assertEQ(cases(6), "def");
+    assertEQ(cases(7), "ghi");
+    assertEQ(cases(8), "ghi");
+    assertEQ(cases(9), "ghi");
+    assertEQ(cases(0), "?");
 }
 
 function testNoDefault() {
@@ -48,10 +48,10 @@ function testNoDefault() {
         return "?";
     }
 
-    assertEquals(cases(1), "a");
-    assertEquals(cases(2), "b");
-    assertEquals(cases(3), "c");
-    assertEquals(cases(4), "?");
+    assertEQ(cases(1), "a");
+    assertEQ(cases(2), "b");
+    assertEQ(cases(3), "c");
+    assertEQ(cases(4), "?");
 }
 
 function testBlocks() {
@@ -72,8 +72,8 @@ function testBlocks() {
         }
     }
 
-    assertEquals(cases(1), "a");
-    assertEquals(cases(2), "b");
-    assertEquals(cases(3), "c");
-    assertEquals(cases(4), "?");
+    assertEQ(cases(1), "a");
+    assertEQ(cases(2), "b");
+    assertEQ(cases(3), "c");
+    assertEQ(cases(4), "?");
 }

--- a/tests/lang_var.joe
+++ b/tests/lang_var.joe
@@ -4,35 +4,35 @@
 
 function testDeclareOnly_normal() {
     var a;
-    assertEquals(a, null);
+    assertEQ(a, null);
 }
 
 function testDeclareOnly_wildcard() {
     var _;
-    assertEquals(_, null);
+    assertEQ(_, null);
 }
 
 function testDeclareAndInitialize_normal() {
     var a = 1;
-    assertEquals(a, 1);
+    assertEQ(a, 1);
 }
 
 function testDeclareAndInitialize_wildcard() {
     var _ = 1;
-    assertEquals(_, 1);
+    assertEQ(_, 1);
 }
 
 function testBind_simple() {
     var [a, b] = [1, 2];
-    assertEquals(a, 1);
-    assertEquals(b, 2);
+    assertEQ(a, 1);
+    assertEQ(b, 2);
 }
 
 function testBind_complex() {
     var a@[b, c] = [1, 2];
-    assertEquals(a, [1, 2]);
-    assertEquals(b, 1);
-    assertEquals(c, 2);
+    assertEQ(a, [1, 2]);
+    assertEQ(b, 1);
+    assertEQ(c, 2);
 }
 
 function testBind_structureMismatch() {

--- a/tests/lang_while.joe
+++ b/tests/lang_while.joe
@@ -8,8 +8,8 @@ function testWhile_simple() {
         sum = sum + i;
     }
 
-    assertEquals(i, 4);
-    assertEquals(sum, 10);
+    assertEQ(i, 4);
+    assertEQ(sum, 10);
 }
 
 function testWhile_continue() {
@@ -21,8 +21,8 @@ function testWhile_continue() {
         sum = sum + i;
     }
 
-    assertEquals(i, 4);
-    assertEquals(sum, 8);  // 1 + 3 + 4
+    assertEQ(i, 4);
+    assertEQ(sum, 8);  // 1 + 3 + 4
 }
 
 
@@ -37,8 +37,8 @@ function testWhile_break_noLocals() {
         sum = sum + i;
     }
 
-    assertEquals(i, 3);
-    assertEquals(sum, 3);
+    assertEQ(i, 3);
+    assertEQ(sum, 3);
 }
 
 function testWhile_break_locals() {
@@ -54,6 +54,6 @@ function testWhile_break_locals() {
         sum = sum + x;
     }
 
-    assertEquals(i, 3);
-    assertEquals(sum, 6);
+    assertEQ(i, 3);
+    assertEQ(sum, 6);
 }

--- a/tests/pkg.joe.joe
+++ b/tests/pkg.joe.joe
@@ -5,31 +5,30 @@
 
 function testCatch_ok() {
     var cr = catch(\-> "abc");
-    check(cr.isOK()).isTrue();
-    check(cr.isError()).isFalse();
-    check(cr.result).eq("abc");
-    check(cr.error).isNull();
-
+    assertTrue(cr.isOK());
+    assertFalse(cr.isError());
+    assertEQ(cr.result, "abc");
+    assertEQ(cr.error, null);
 }
 
 function testCatch_error() {
     function bad() { throw "Simulated error!"; }
     var cr = catch(bad);
-    check(cr.isOK()).isFalse();
-    check(cr.isError()).isTrue();
-    check(cr.result).eq(null);
-    check(cr.error.message()).eq("Simulated error!");
+    assertFalse(cr.isOK());
+    assertTrue(cr.isError());
+    assertEQ(cr.result, null);
+    assertEQ(cr.error.message(), "Simulated error!");
 }
 
 function testCatch_error_withTrace() {
     function bad() { throw "Simulated error!"; }
     var cr = catch(bad);
-    check(cr.isOK()).isFalse();
-    check(cr.isError()).isTrue();
-    check(cr.result).eq(null);
-    check(cr.error.message()).eq("Simulated error!");
+    assertFalse(cr.isOK());
+    assertTrue(cr.isError());
+    assertEQ(cr.result, null);
+    assertEQ(cr.error.message(), "Simulated error!");
 
-    check(cr.error.traces()).eq([
+    assertEQ(cr.error.traces(), [
         "In function bad()",
         "In java call(<function bad()>)",
         "Called from catch()",

--- a/tests/pkg.joe.joe
+++ b/tests/pkg.joe.joe
@@ -5,8 +5,8 @@
 
 function testCatch_ok() {
     var cr = catch(\-> "abc");
-    assertTrue(cr.isOK());
-    assertFalse(cr.isError());
+    assertT(cr.isOK());
+    assertF(cr.isError());
     assertEQ(cr.result, "abc");
     assertEQ(cr.error, null);
 }
@@ -14,8 +14,8 @@ function testCatch_ok() {
 function testCatch_error() {
     function bad() { throw "Simulated error!"; }
     var cr = catch(bad);
-    assertFalse(cr.isOK());
-    assertTrue(cr.isError());
+    assertF(cr.isOK());
+    assertT(cr.isError());
     assertEQ(cr.result, null);
     assertEQ(cr.error.message(), "Simulated error!");
 }
@@ -23,8 +23,8 @@ function testCatch_error() {
 function testCatch_error_withTrace() {
     function bad() { throw "Simulated error!"; }
     var cr = catch(bad);
-    assertFalse(cr.isOK());
-    assertTrue(cr.isError());
+    assertF(cr.isOK());
+    assertT(cr.isError());
     assertEQ(cr.result, null);
     assertEQ(cr.error.message(), "Simulated error!");
 

--- a/tests/pkg.joe.test.joe
+++ b/tests/pkg.joe.test.joe
@@ -2,15 +2,73 @@
 
 //-------------------------------------------------------------------------
 // Basic Test API
-//
-// Section copied to bert/pkg_test.joe
 
-function testAssertEquals() {
+function testAssertEquals_scalar() {
     assertEquals(5, 5);
     assertEquals("abc", "abc");
+    assertError(\-> assertEquals("abc", 5), """
+        Computed: String 'abc'
+        Expected: Number '5'
+        """
+    );
+}
 
-    function bad() { assertEquals("abc", 5); }
-    assertError(bad, "Expected Number '5', got: String 'abc'.");
+function testAssertEquals_list() {
+    var a = List.of("a", "b", "c");
+    var b = List.of("a", "b", "c", "d");
+    assertEquals(a, a);
+    assertError(\-> assertEquals(a, b), """
+        Computed: List [
+            String 'a'
+            String 'b'
+            String 'c'
+        ]
+        Expected: List [
+            String 'a'
+            String 'b'
+            String 'c'
+            String 'd'
+        ]
+        """
+    );
+}
+
+function testAssertEquals_set() {
+    var a = Set.of("a", "b", "c");
+    var b = Set.of("a", "b", "c", "d");
+    assertEquals(a, a);
+    assertError(\-> assertEquals(a, b), """
+        Computed: Set {
+            String 'a'
+            String 'b'
+            String 'c'
+        }
+        Expected: Set {
+            String 'a'
+            String 'b'
+            String 'c'
+            String 'd'
+        }
+        """
+    );
+}
+
+function testAssertEquals_map() {
+    var a = Map.of("a", 1.0, "b", 2.0);
+    var b = Map.of("a", 1.0, "b", 2.0, "c", 3.0);
+    assertEquals(a, a);
+    assertError(\-> assertEquals(a, b), """
+        Computed: Map {
+            String 'a': Number '1'
+            String 'b': Number '2'
+        }
+        Expected: Map {
+            String 'a': Number '1'
+            String 'b': Number '2'
+            String 'c': Number '3'
+        }
+        """
+    );
 }
 
 function testAssertTrue() {

--- a/tests/pkg.joe.test.joe
+++ b/tests/pkg.joe.test.joe
@@ -72,18 +72,18 @@ function testAssertEquals_map() {
 }
 
 function testAssertTrue() {
-    assertTrue(true);
-    assertTrue("abc");
+    assertT(true);
+    assertT("abc");
 
-    function bad() { assertTrue(false); }
+    function bad() { assertT(false); }
     assertError(bad, "Expected truthy value, got: Boolean 'false'.");
 }
 
 function testAssertFalse() {
-    assertFalse(false);
-    assertFalse(null);
+    assertF(false);
+    assertF(null);
 
-    function bad() { assertFalse(true); }
+    function bad() { assertF(true); }
     assertError(bad, "Expected falsey value, got: Boolean 'true'.");
 }
 

--- a/tests/pkg.joe.test.joe
+++ b/tests/pkg.joe.test.joe
@@ -4,9 +4,9 @@
 // Basic Test API
 
 function testAssertEquals_scalar() {
-    assertEquals(5, 5);
-    assertEquals("abc", "abc");
-    assertError(\-> assertEquals("abc", 5), """
+    assertEQ(5, 5);
+    assertEQ("abc", "abc");
+    assertError(\-> assertEQ("abc", 5), """
         Computed: String 'abc'
         Expected: Number '5'
         """
@@ -16,8 +16,8 @@ function testAssertEquals_scalar() {
 function testAssertEquals_list() {
     var a = List.of("a", "b", "c");
     var b = List.of("a", "b", "c", "d");
-    assertEquals(a, a);
-    assertError(\-> assertEquals(a, b), """
+    assertEQ(a, a);
+    assertError(\-> assertEQ(a, b), """
         Computed: List [
             String 'a'
             String 'b'
@@ -36,8 +36,8 @@ function testAssertEquals_list() {
 function testAssertEquals_set() {
     var a = Set.of("a", "b", "c");
     var b = Set.of("a", "b", "c", "d");
-    assertEquals(a, a);
-    assertError(\-> assertEquals(a, b), """
+    assertEQ(a, a);
+    assertError(\-> assertEQ(a, b), """
         Computed: Set {
             String 'a'
             String 'b'
@@ -56,8 +56,8 @@ function testAssertEquals_set() {
 function testAssertEquals_map() {
     var a = Map.of("a", 1.0, "b", 2.0);
     var b = Map.of("a", 1.0, "b", 2.0, "c", 3.0);
-    assertEquals(a, a);
-    assertError(\-> assertEquals(a, b), """
+    assertEQ(a, a);
+    assertError(\-> assertEQ(a, b), """
         Computed: Map {
             String 'a': Number '1'
             String 'b': Number '2'

--- a/tests/type.joe.AssertError.joe
+++ b/tests/type.joe.AssertError.joe
@@ -4,19 +4,19 @@
 
 function testInitializer_noFrames() {
     var err = AssertError("Failure");
-    check(err.message()).eq("Failure");
-    check(err.traces()).isEmpty();
+    assertEQ(err.message(), "Failure");
+    assertEmpty(err.traces());
 }
 
 function testInitializer_frames() {
     var err = AssertError("Failure", "A", "B");
-    check(err.message()).eq("Failure");
-    check(err.traces()).eq(["A", "B"]);
+    assertEQ(err.message(), "Failure");
+    assertEQ(err.traces(), ["A", "B"]);
 }
 
 function testCanThrow() {
     var err = AssertError("Failure", "A", "B");
-    checkCatch(\-> { throw err; })
-        .message("Failure");
+    assertError(\-> { throw err; },
+        "Failure");
 }
 

--- a/tests/type.joe.Error.joe
+++ b/tests/type.joe.Error.joe
@@ -4,22 +4,22 @@
 
 function testInitializer_simple() {
     var error = Error("Message");
-    check(error.message()).eq("Message");
-    check(error.type()).eq("JoeError");
-    check(error.traces()).isEmpty();
-    check(error.stackTrace()).eq(error.message());
+    assertEQ(error.message(), "Message");
+    assertEQ(error.type(), "JoeError");
+    assertEmpty(error.traces());
+    assertEQ(error.stackTrace(), error.message());
 }
 
 function testInitializer_withTraces() {
     var error = Error("Message", "A", "B");
-    check(error.message()).eq("Message");
-    check(error.type()).eq("JoeError");
-    check(error.traces()).eq(["A", "B"]);
+    assertEQ(error.message(), "Message");
+    assertEQ(error.type(), "JoeError");
+    assertEQ(error.traces(), ["A", "B"]);
 }
 
 function testAddInfo() {
     var error = Error("Message");
-    check(error.traces()).isEmpty();
+    assertEmpty(error.traces());
     error.addInfo("A");
-    check(error.traces()).eq(["A"]);
+    assertEQ(error.traces(), ["A"]);
 }

--- a/tests/type.joe.Fact.joe
+++ b/tests/type.joe.Fact.joe
@@ -4,13 +4,13 @@
 
 function testInitializer_good() {
     var fact = Fact("Thing", #car, #red);
-    check(fact.relation()).eq("Thing");
-    check(fact.isOrdered()).eq(true);
-    check(fact.fields()).eq([#car, #red]);
-    check(fact.fieldMap()).eq({"f0": #car, "f1": #red});
-    check(fact.f0).eq(#car);
-    check(fact.f1).eq(#red);
-    check(fact.toString()).eq("Fact(Thing, #car, #red)");
+    assertEQ(fact.relation(), "Thing");
+    assertT(fact.isOrdered());
+    assertEQ(fact.fields(), [#car, #red]);
+    assertEQ(fact.fieldMap(), {"f0": #car, "f1": #red});
+    assertEQ(fact.f0, #car);
+    assertEQ(fact.f1, #red);
+    assertEQ(fact.toString(), "Fact(Thing, #car, #red)");
 }
 
 function testInitializer_badRelation() {
@@ -20,13 +20,13 @@ function testInitializer_badRelation() {
 
 function testOf() {
     var fact = Fact.of("Thing", [#car, #red]);
-    check(fact.relation()).eq("Thing");
-    check(fact.isOrdered()).eq(true);
-    check(fact.fields()).eq([#car, #red]);
-    check(fact.fieldMap()).eq({"f0": #car, "f1": #red});
-    check(fact.f0).eq(#car);
-    check(fact.f1).eq(#red);
-    check(fact.toString()).eq("Fact(Thing, #car, #red)");
+    assertEQ(fact.relation(), "Thing");
+    assertT(fact.isOrdered());
+    assertEQ(fact.fields(), [#car, #red]);
+    assertEQ(fact.fieldMap(), {"f0": #car, "f1": #red});
+    assertEQ(fact.f0, #car);
+    assertEQ(fact.f1, #red);
+    assertEQ(fact.toString(), "Fact(Thing, #car, #red)");
 }
 
 function testOf_badRelation() {
@@ -36,11 +36,11 @@ function testOf_badRelation() {
 
 function testOfMap() {
     var fact = Fact.ofMap("Thing", {"id": #car, "color": #red});
-    check(fact.relation()).eq("Thing");
-    check(fact.isOrdered()).eq(false);
-    check(fact.fieldMap()).eq({"id": #car, "color": #red});
-    check(fact.id).eq(#car);
-    check(fact.color).eq(#red);
+    assertEQ(fact.relation(), "Thing");
+    assertF(fact.isOrdered());
+    assertEQ(fact.fieldMap(), {"id": #car, "color": #red});
+    assertEQ(fact.id, #car);
+    assertEQ(fact.color, #red);
 }
 
 function testOfMap_badRelation() {
@@ -55,13 +55,13 @@ function testOfMap_badFieldName() {
 
 function testOfPairs() {
     var fact = Fact.ofPairs("Thing", ["id", #car, "color", #red]);
-    check(fact.relation()).eq("Thing");
-    check(fact.isOrdered()).eq(true);
-    check(fact.fields()).eq([#car, #red]);
-    check(fact.fieldMap()).eq({"id": #car, "color": #red});
-    check(fact.id).eq(#car);
-    check(fact.color).eq(#red);
-    check(fact.toString()).eq("Fact(Thing, #car, #red)");
+    assertEQ(fact.relation(), "Thing");
+    assertT(fact.isOrdered());
+    assertEQ(fact.fields(), [#car, #red]);
+    assertEQ(fact.fieldMap(), {"id": #car, "color": #red});
+    assertEQ(fact.id, #car);
+    assertEQ(fact.color, #red);
+    assertEQ(fact.toString(), "Fact(Thing, #car, #red)");
 }
 
 function testOfPairs_badRelation() {
@@ -82,20 +82,20 @@ function testBadField() {
 
 function testMatch_listFact() {
     var fact = Fact("Thing", #car, #red);
-    check(fact ~ Thing(#car, _)).eq(true);
-    check(fact ~ Thing(#bus, _)).eq(false);
+    assertT(fact ~ Thing(#car, _));
+    assertF(fact ~ Thing(#bus, _));
 }
 
 function testMatch_mapFact() {
     var fact = Fact.ofMap("Thing", {"id": #car, "color": #red});
-    check(fact ~ Thing(#car, _)).eq(false);
-    check(fact ~ Thing(id: #car)).eq(true);
+    assertF(fact ~ Thing(#car, _));
+    assertT(fact ~ Thing(id: #car));
 }
 
 function testMatch_recordFact() {
     var fact = Fact.ofPairs("Thing", ["id", #car, "color", #red]);
-    check(fact ~ Thing(#car, _)).eq(true);
-    check(fact ~ Thing(id: #car)).eq(true);
-    check(fact ~ Thing(#bus, _)).eq(false);
-    check(fact ~ Thing(id: #bus)).eq(false);
+    assertT(fact ~ Thing(#car, _));
+    assertT(fact ~ Thing(id: #car));
+    assertF(fact ~ Thing(#bus, _));
+    assertF(fact ~ Thing(id: #bus));
 }

--- a/tests/type.joe.FactBase.joe
+++ b/tests/type.joe.FactBase.joe
@@ -23,38 +23,38 @@ var HAT_FACT = Joe.toFact(HAT);
 
 function testCreation_empty() {
     var db = FactBase();
-    check(db.isEmpty()).eq(true);
-    check(db.size()).eq(0);
-    check(db.all().isEmpty()).eq(true);
-    check(db.relations().isEmpty()).eq(true);
-    check(db.relation("Thing").isEmpty()).eq(true);
-    check(db.toString()).eq("FactBase[0]");
+    assertEmpty(db);
+    assertEQ(db.size(), 0);
+    assertT(db.all().isEmpty());
+    assertT(db.relations().isEmpty());
+    assertT(db.relation("Thing").isEmpty());
+    assertEQ(db.toString(), "FactBase[0]");
 }
 
 function testCreation_collection() {
     var db = FactBase([JOE, TEXAS, HAT]);
-    check(db.isEmpty()).eq(false);
-    check(db.size()).eq(3);
-    check(db.all().isEmpty()).eq(false);
-    check(db.all()).eq(Set.of(JOE_FACT, TEXAS_FACT, HAT_FACT));
-    check(db.relations().isEmpty()).eq(false);
-    check(db.relations()).eq(Set.of("Person", "Place", "Thing"));
-    check(db.relation("Person")).eq(Set.of(JOE_FACT));
-    check(db.toString()).eq("FactBase[3, Person[1], Place[1], Thing[1]]");
+    assertF(db.isEmpty());
+    assertEQ(db.size(), 3);
+    assertF(db.all().isEmpty());
+    assertEQ(db.all(), {JOE_FACT, TEXAS_FACT, HAT_FACT});
+    assertF(db.relations().isEmpty());
+    assertEQ(db.relations(), {"Person", "Place", "Thing"});
+    assertEQ(db.relation("Person"), {JOE_FACT});
+    assertEQ(db.toString(), "FactBase[3, Person[1], Place[1], Thing[1]]");
 }
 
 function testCreation_FactBase() {
     var other = FactBase([JOE, HAT]);
 
     var db = FactBase(other);
-    check(db.isEmpty()).eq(false);
-    check(db.size()).eq(2);
-    check(db.all().isEmpty()).eq(false);
-    check(db.all()).eq(other.all());
-    check(db.relations().isEmpty()).eq(false);
-    check(db.relations()).eq(other.relations());
-    check(db.relation("Person")).eq(other.relation("Person"));
-    check(db.toString()).eq("FactBase[2, Person[1], Thing[1]]");
+    assertF(db.isEmpty());
+    assertEQ(db.size(), 2);
+    assertF(db.all().isEmpty());
+    assertEQ(db.all(), other.all());
+    assertF(db.relations().isEmpty());
+    assertEQ(db.relations(), other.relations());
+    assertEQ(db.relation("Person"), other.relation("Person"));
+    assertEQ(db.toString(), "FactBase[2, Person[1], Thing[1]]");
 }
 
 function testCreation_badInputs() {
@@ -72,7 +72,7 @@ function testIterable() {
 
     var set = Set();
     foreach(fact : db) set.add(fact);
-    check(set).eq(db.all());
+    assertEQ(set, db.all());
 }
 
 
@@ -84,9 +84,9 @@ function testAdd_good() {
 
     db.add(JOE);
 
-    check(db.all()).eq(Set.of(JOE_FACT));
-    check(db.relation("Person")).eq(Set.of(JOE_FACT));
-    check(db.relations()).eq(Set.of("Person"));
+    assertEQ(db.all(), {JOE_FACT});
+    assertEQ(db.relation("Person"), {JOE_FACT});
+    assertEQ(db.relations(), {"Person"});
 }
 
 function testAdd_bad() {
@@ -102,8 +102,8 @@ function testAdd_bad() {
 function testAddAll_collection() {
     var db = FactBase();
     db.addAll([JOE, HAT]);
-    check(db.all()).eq(Set.of(JOE_FACT, HAT_FACT));
-    check(db.relation("Person")).eq(Set.of(JOE_FACT));
+    assertEQ(db.all(), {JOE_FACT, HAT_FACT});
+    assertEQ(db.relation("Person"), {JOE_FACT});
 }
 
 function testAddAll_FactBase() {
@@ -111,8 +111,8 @@ function testAddAll_FactBase() {
     var other = FactBase([JOE, HAT]);
 
     db.addAll(other);
-    check(db.all()).eq(other.all());
-    check(db.relation("Person")).eq(other.relation("Person"));
+    assertEQ(db.all(), other.all());
+    assertEQ(db.relation("Person"), other.relation("Person"));
 }
 
 function testAddAll_badInputs() {
@@ -135,10 +135,10 @@ function testClear() {
     var db = FactBase();
     db.add(JOE);
     db.clear();
-    check(db.isEmpty()).eq(true);
-    check(db.size()).eq(0);
-    check(db.all().isEmpty()).eq(true);
-    check(db.relations().isEmpty()).eq(true);
+    assertT(db.isEmpty());
+    assertEQ(db.size(), 0);
+    assertT(db.all().isEmpty());
+    assertT(db.relations().isEmpty());
 }
 
 //-------------------------------------------------------------------------
@@ -147,8 +147,8 @@ function testClear() {
 function testDrop() {
     var db = FactBase([JOE, TEXAS, HAT]);
     db.drop("Thing");
-    check(db.all()).eq(Set.of(JOE_FACT, TEXAS_FACT));
-    check(db.relation("Thing")).eq(Set());
+    assertEQ(db.all(), {JOE_FACT, TEXAS_FACT});
+    assertEQ(db.relation("Thing"), Set());
 }
 
 //-------------------------------------------------------------------------
@@ -158,7 +158,7 @@ function testFilter() {
     var db = FactBase([JOE, TEXAS, HAT]);
 
     var set = db.filter(\f -> f ~ Person());
-    check(set).eq(Set.of(JOE_FACT));
+    assertEQ(set, {JOE_FACT});
 }
 
 //-------------------------------------------------------------------------
@@ -166,11 +166,11 @@ function testFilter() {
 
 function testDebug_setGet() {
     var db = FactBase();
-    check(db.isDebug()).eq(false);
+    assertF(db.isDebug());
     db.setDebug(true);
-    check(db.isDebug()).eq(true);
+    assertT(db.isDebug());
     db.setDebug(false);
-    check(db.isDebug()).eq(false);
+    assertF(db.isDebug());
 }
 
 //-------------------------------------------------------------------------
@@ -184,7 +184,7 @@ function testDebug_setGet() {
 function testMap() {
     var db = FactBase([JOE, TEXAS, HAT]);
     var strings = db.map(Joe.stringify).sorted();
-    check(strings).eq([
+    assertEQ(strings, [
         "Fact(Person, #joe, 90)",
         "Fact(Place, #texas)",
         "Fact(Thing, #hat, #black)"
@@ -208,8 +208,8 @@ function testRemove_good() {
     var db = FactBase([JOE, TEXAS, HAT]);
     db.remove(HAT);
 
-    check(db.all()).eq(Set.of(JOE_FACT, TEXAS_FACT));
-    check(db.relation("Thing")).eq(Set());
+    assertEQ(db.all(), {JOE_FACT, TEXAS_FACT});
+    assertEQ(db.relation("Thing"), Set());
 }
 
 function testRemove_bad() {
@@ -230,8 +230,8 @@ function testRemoveAll_collection() {
     var db = FactBase([JOE, TEXAS, HAT]);
     db.removeAll([HAT]);
 
-    check(db.all()).eq(Set.of(JOE_FACT, TEXAS_FACT));
-    check(db.relation("Thing")).eq(Set());
+    assertEQ(db.all(), {JOE_FACT, TEXAS_FACT});
+    assertEQ(db.relation("Thing"), Set());
 }
 
 function testRemoveAll_FactBase() {
@@ -239,8 +239,8 @@ function testRemoveAll_FactBase() {
     var other = FactBase([HAT]);
     db.removeAll(other);
 
-    check(db.all()).eq(Set.of(JOE_FACT, TEXAS_FACT));
-    check(db.relation("Thing")).eq(Set());
+    assertEQ(db.all(), {JOE_FACT, TEXAS_FACT});
+    assertEQ(db.relation("Thing"), Set());
 }
 
 function testRemoveAll_bad() {
@@ -256,8 +256,8 @@ function testRemoveAll_bad() {
 function testRemoveIf() {
     var db = FactBase([JOE, TEXAS, HAT]);
     db.removeIf(\f -> f ~ Thing());
-    check(db.all()).eq(Set.of(JOE_FACT, TEXAS_FACT));
-    check(db.relation("Thing")).eq(Set());
+    assertEQ(db.all(), {JOE_FACT, TEXAS_FACT});
+    assertEQ(db.relation("Thing"), Set());
 }
 
 //-------------------------------------------------------------------------
@@ -267,9 +267,9 @@ function testRename() {
     var db = FactBase([JOE, TEXAS, HAT]);
     var newFact = Fact.ofPairs("Location", ["id", #texas]);
     db.rename("Place", "Location");
-    check(db.all()).eq(Set.of(JOE_FACT, newFact, HAT_FACT));
-    check(db.relation("Place")).eq(Set());
-    check(db.relation("Location")).eq(Set.of(newFact));
+    assertEQ(db.all(), {JOE_FACT, newFact, HAT_FACT});
+    assertEQ(db.relation("Place"), Set());
+    assertEQ(db.relation("Location"), {newFact});
 }
 
 //-------------------------------------------------------------------------
@@ -286,12 +286,12 @@ function testSelect_facts() {
         Ancestor(x, y) :- Parent(x, z), Ancestor(z, y);
     });
 
-    var expected = Set.of(
+    var expected = {
         Fact("Ancestor", #anne, #bert),
         Fact("Ancestor", #anne, #clark),
         Fact("Ancestor", #bert, #clark)
-    );
-    check(results).eq(expected);
+    };
+    assertEQ(results, expected);
 }
 
 
@@ -319,16 +319,16 @@ function testUpdate_good() {
         Ancestor(x, y) :- Parent(x, z), Ancestor(z, y);
     });
 
-    var expected = Set.of(
+    var expected = {
         Fact("Ancestor", #anne, #bert),
         Fact("Ancestor", #anne, #clark),
         Fact("Ancestor", #bert, #clark)
-    );
+    };
 
     // The relation's set was updated.
-    check(db.relation("Ancestor")).eq(expected);
+    assertEQ(db.relation("Ancestor"), expected);
 
     // The set of all facts was updated.
-    check(db.all().containsAll(expected)).eq(true);
+    assertT(db.all().containsAll(expected));
 }
 

--- a/tests/type.joe.Joe.joe
+++ b/tests/type.joe.Joe.joe
@@ -21,58 +21,58 @@ class MyTextBuilder extends TextBuilder {
 // compare()
 
 function testCompare_string() {
-    check(Joe.compare("a", "b")).eq(-1);
-    check(Joe.compare("b", "b")).eq(0);
-    check(Joe.compare("c", "b")).eq(1);
+    assertEQ(Joe.compare("a", "b"), -1);
+    assertEQ(Joe.compare("b", "b"), 0);
+    assertEQ(Joe.compare("c", "b"), 1);
 }
 
 function testCompare_number() {
-    check(Joe.compare(0, 1)).eq(-1);
-    check(Joe.compare(1, 1)).eq(0);
-    check(Joe.compare(2, 1)).eq(1);
+    assertEQ(Joe.compare(0, 1), -1);
+    assertEQ(Joe.compare(1, 1), 0);
+    assertEQ(Joe.compare(2, 1), 1);
 }
 
 function testCompare_mismatch() {
-    checkCatch(\-> Joe.compare(1, #a))
-        .message("Expected two strings or two numbers.");
+    assertError(\-> Joe.compare(1, #a),
+        "Expected two strings or two numbers.");
 }
 
 //-----------------------------------------------------------------------------
 // Joe.getFieldNames()
 
 function testGetFieldNames() {
-    check(Joe.getFieldNames("abc")).eq([]);
-    check(Joe.getFieldNames(String)).eq([]);
+    assertEQ(Joe.getFieldNames("abc"), []);
+    assertEQ(Joe.getFieldNames(String), []);
 
-    check(Joe.getFieldNames(Thing)).eq([]);
+    assertEQ(Joe.getFieldNames(Thing), []);
     Thing.x = 5;
-    check(Joe.getFieldNames(Thing)).eq(["x"]);
+    assertEQ(Joe.getFieldNames(Thing), ["x"]);
 
     var thing = Thing(123, "red");
-    check(Joe.getFieldNames(thing).sorted()).eq(["color", "id"]);
+    assertEQ(Joe.getFieldNames(thing).sorted(), ["color", "id"]);
 }
 
 //-----------------------------------------------------------------------------
 // Joe.isOpaque()
 
 function testIsOpaque() {
-    check(Joe.isOpaque(JoeTest.OPAQUE)).isTrue();
-    check(Joe.isOpaque("abc")).isFalse();
+    assertT(Joe.isOpaque(JoeTest.OPAQUE));
+    assertF(Joe.isOpaque("abc"));
 }
 
 //-----------------------------------------------------------------------------
 // Joe.isType()
 
 function testIsType() {
-    check(Joe.isType(String)).isTrue();
-    check(Joe.isType("abc")).isFalse();
+    assertT(Joe.isType(String));
+    assertF(Joe.isType("abc"));
 }
 
 //-------------------------------------------------------------------------
 // Joe.name()
 
 function testName() {
-    check(Joe.name()).eq("Joe");
+    assertEQ(Joe.name(), "Joe");
 }
 
 //-----------------------------------------------------------------------------
@@ -81,8 +81,8 @@ function testName() {
 // This just just verifies that the function exists; specific types
 // test their own stringification.
 function testStringify() {
-    check(Joe.stringify("abc")).eq("abc");
-    check(Joe.stringify(1.0)).eq("1");
+    assertEQ(Joe.stringify("abc"), "abc");
+    assertEQ(Joe.stringify(1.0), "1");
 }
 
 //-----------------------------------------------------------------------------
@@ -90,19 +90,19 @@ function testStringify() {
 
 function testSupertypeOf() {
     // Native Joe
-    check(Joe.supertypeOf(String)).isNull();
+    assertEQ(Joe.supertypeOf(String), null);
 
     // Scripted base class
-    check(Joe.supertypeOf(Thing)).isNull();
+    assertEQ(Joe.supertypeOf(Thing), null);
 
     // Subclass of scripted base class
-    check(Joe.supertypeOf(Gizmo)).eq(Thing);
+    assertEQ(Joe.supertypeOf(Gizmo), Thing);
 
     // Native base class
-    check(Joe.supertypeOf(TextBuilder)).eq(null);
+    assertEQ(Joe.supertypeOf(TextBuilder), null);
 
     // Subclass of native base class
-    check(Joe.supertypeOf(MyTextBuilder)).eq(TextBuilder);
+    assertEQ(Joe.supertypeOf(MyTextBuilder), TextBuilder);
 }
 
 //-----------------------------------------------------------------------------
@@ -111,9 +111,9 @@ function testSupertypeOf() {
 function testTypeOf() {
     var thing = Thing(123, "red");
 
-    check(Joe.typeOf("abc")).eq(String);
-    check(Joe.typeOf(String)).eq(Type);
-    check(Joe.typeOf(thing)).eq(Thing);
-    check(Joe.typeOf(Thing)).eq(Type);
-    check(Joe.typeOf(Joe)).eq(Type);
+    assertEQ(Joe.typeOf("abc"), String);
+    assertEQ(Joe.typeOf(String), Type);
+    assertEQ(Joe.typeOf(thing), Thing);
+    assertEQ(Joe.typeOf(Thing), Type);
+    assertEQ(Joe.typeOf(Joe), Type);
 }

--- a/tests/type.joe.Keyword.joe
+++ b/tests/type.joe.Keyword.joe
@@ -3,17 +3,17 @@
 // Keyword tests
 
 function testInitializer() {
-    check(Keyword("abc")).eq(#abc);
-    check(Keyword("#abc")).eq(#abc);
+    assertEQ(Keyword("abc"), #abc);
+    assertEQ(Keyword("#abc"), #abc);
 
-    checkCatch(\-> Keyword("a@"))
-        .message("Expected keyword name, got: String 'a@'.");
+    assertError(\-> Keyword("a@"),
+        "Expected keyword name, got: String 'a@'.");
 }
 
 function testName() {
-    check(#abc.name()).eq("abc");
+    assertEQ(#abc.name(), "abc");
 }
 
 function testToString() {
-    check(#abc.toString()).eq("#abc");
+    assertEQ(#abc.toString(), "#abc");
 }

--- a/tests/type.joe.List.joe
+++ b/tests/type.joe.List.joe
@@ -4,11 +4,11 @@
 // List.of()
 
 function testOf_empty() {
-    check(List.of()).eq([]);
+    assertEQ(List.of(), []);
 }
 
 function testOf_items() {
-    check(List.of(1, 2, 3)).eq([1, 2, 3]);
+    assertEQ(List.of(1, 2, 3), [1, 2, 3]);
 }
 
 
@@ -16,19 +16,19 @@ function testOf_items() {
 // List()
 
 function testCreate_empty() {
-    check(List()).eq([]);
+    assertEQ(List(), []);
 }
 
 function testCreate_fromList() {
-    check(List([1, 2, 3])).eq([1, 2, 3]);
+    assertEQ(List([1, 2, 3]), [1, 2, 3]);
 }
 
 function testCreate_withSize() {
-    check(List(3)).eq([null, null, null]);
+    assertEQ(List(3), [null, null, null]);
 }
 
 function testCreate_withSizeAndValue() {
-    check(List(3, "x")).eq(["x", "x", "x"]);
+    assertEQ(List(3, "x"), ["x", "x", "x"]);
 }
 
 //-----------------------------------------------------------------------------
@@ -36,19 +36,19 @@ function testCreate_withSizeAndValue() {
 
 function testAdd_simple() {
     var list = [];
-    check(list.add(1)).eq([1]);
-    check(list.add(2)).eq([1, 2]);
-    check(list.add(3)).eq([1, 2, 3]);
+    assertEQ(list.add(1), [1]);
+    assertEQ(list.add(2), [1, 2]);
+    assertEQ(list.add(3), [1, 2, 3]);
 }
 
 function testAdd_index() {
     var list = [];
-    check(list.add(1)).eq([1]);
-    check(list.add(0, 2)).eq([2, 1]);
-    check(list.add(1, 3)).eq([2, 3, 1]);
+    assertEQ(list.add(1), [1]);
+    assertEQ(list.add(0, 2), [2, 1]);
+    assertEQ(list.add(1, 3), [2, 3, 1]);
 
-    checkCatch(\-> list.add(-1, 4))
-        .message("Expected 0 <= index < 4, got: Number '-1'.");
+    assertError(\-> list.add(-1, 4),
+        "Expected 0 <= index < 4, got: Number '-1'.");
 }
 
 //-----------------------------------------------------------------------------
@@ -56,18 +56,18 @@ function testAdd_index() {
 
 function testAddAll_simple() {
     var list = [1, 2];
-    check(list.addAll([3, 4, 5])).eq([1, 2, 3, 4, 5]);
+    assertEQ(list.addAll([3, 4, 5]), [1, 2, 3, 4, 5]);
 
-    checkCatch(\-> list.addAll(6))
-        .message("Expected List, got: Number '6'.");
+    assertError(\-> list.addAll(6),
+        "Expected List, got: Number '6'.");
 }
 
 function testAddAll_index() {
     var list = [1, 5];
-    check(list.addAll(1, [2, 3, 4])).eq([1, 2, 3, 4, 5]);
+    assertEQ(list.addAll(1, [2, 3, 4]), [1, 2, 3, 4, 5]);
 
-    checkCatch(\-> list.addAll(-1, []))
-        .message("Expected 0 <= index < 6, got: Number '-1'.");
+    assertError(\-> list.addAll(-1, []),
+        "Expected 0 <= index < 6, got: Number '-1'.");
 }
 
 //-----------------------------------------------------------------------------
@@ -75,7 +75,7 @@ function testAddAll_index() {
 
 function testClear() {
     var list = [1, 2, 3];
-    check(list.clear()).eq([]);
+    assertEQ(list.clear(), []);
 }
 
 //-----------------------------------------------------------------------------
@@ -83,8 +83,8 @@ function testClear() {
 
 function testContains() {
     var list = [1, 2, 3];
-    check(list.contains(2)).eq(true);
-    check(list.contains(4)).eq(false);
+    assertEQ(list.contains(2), true);
+    assertEQ(list.contains(4), false);
 }
 
 //-----------------------------------------------------------------------------
@@ -92,8 +92,8 @@ function testContains() {
 
 function testContainsAll() {
     var list = [1, 2, 3];
-    check(list.containsAll([2, 3])).eq(true);
-    check(list.containsAll([4])).eq(false);
+    assertEQ(list.containsAll([2, 3]), true);
+    assertEQ(list.containsAll([4]), false);
 }
 
 //-----------------------------------------------------------------------------
@@ -103,8 +103,8 @@ function testCopy() {
     var a = [1, 2, 3];
     var b = a.copy();
     a.clear();
-    check(a.size()).eq(0);
-    check(b).eq([1, 2, 3]);
+    assertEQ(a.size(), 0);
+    assertEQ(b, [1, 2, 3]);
 }
 
 //-----------------------------------------------------------------------------
@@ -112,9 +112,9 @@ function testCopy() {
 
 function testFilter() {
     var list = [1, 2, 3, 4, 5];
-    check(list.filter(\item -> true)).eq(list);
-    check(list.filter(\item -> item > 3)).eq([4, 5]);
-    check(list.filter(\item -> item == "a")).eq([]);
+    assertEQ(list.filter(\item -> true), list);
+    assertEQ(list.filter(\item -> item > 3), [4, 5]);
+    assertEQ(list.filter(\item -> item == "a"), []);
 }
 
 //-----------------------------------------------------------------------------
@@ -123,19 +123,19 @@ function testFilter() {
 function testFind_notFound() {
     var list = ["abc", "def", "ghi", "efg"];
     var result = list.find(\s -> s.contains("xy"));
-    check(result).eq(null);
+    assertEQ(result, null);
 }
 
 function testFind_noStart() {
     var list = ["abc", "def", "ghi", "efg"];
     var result = list.find(\s -> s.contains("ef"));
-    check(result).eq([1, "def"]);
+    assertEQ(result, [1, "def"]);
 }
 
 function testFind_start() {
     var list = ["abc", "def", "ghi", "efg"];
     var result = list.find(\s -> s.contains("ef"), 2);
-    check(result).eq([3, "efg"]);
+    assertEQ(result, [3, "efg"]);
 }
 
 //-----------------------------------------------------------------------------
@@ -143,11 +143,11 @@ function testFind_start() {
 
 function testGet() {
     var list = [1, 2, 3];
-    check(list.get(0)).eq(1);
-    check(list.get(2)).eq(3);
+    assertEQ(list.get(0), 1);
+    assertEQ(list.get(2), 3);
 
-    checkCatch(\-> list.get(4))
-        .message("Expected 0 <= index < 3, got: Number '4'.");
+    assertError(\-> list.get(4),
+        "Expected 0 <= index < 3, got: Number '4'.");
 }
 
 //-----------------------------------------------------------------------------
@@ -155,10 +155,10 @@ function testGet() {
 
 function testGetFirst() {
     var list = [1, 2, 3];
-    check(list.getFirst()).eq(1);
+    assertEQ(list.getFirst(), 1);
 
-    checkCatch(\-> [].getFirst())
-        .message("List is empty.");
+    assertError(\-> [].getFirst(),
+        "List is empty.");
 }
 
 //-----------------------------------------------------------------------------
@@ -166,10 +166,10 @@ function testGetFirst() {
 
 function testGetLast() {
     var list = [1, 2, 3];
-    check(list.getLast()).eq(3);
+    assertEQ(list.getLast(), 3);
 
-    checkCatch(\-> [].getLast())
-        .message("List is empty.");
+    assertError(\-> [].getLast(),
+        "List is empty.");
 }
 
 //-----------------------------------------------------------------------------
@@ -177,16 +177,16 @@ function testGetLast() {
 
 function testIndexOf() {
     var list = [1, 2, 3, 2, 1];
-    check(list.indexOf(2)).eq(1);
-    check(list.indexOf(4)).eq(-1);
+    assertEQ(list.indexOf(2), 1);
+    assertEQ(list.indexOf(4), -1);
 }
 
 //-----------------------------------------------------------------------------
 // isEmpty()
 
 function testIsEmpty() {
-    check([1].isEmpty()).eq(false);
-    check([].isEmpty()).eq(true);
+    assertEQ([1].isEmpty(), false);
+    assertEQ([].isEmpty(), true);
 }
 
 //-----------------------------------------------------------------------------
@@ -194,8 +194,8 @@ function testIsEmpty() {
 
 function testLastIndexOf() {
     var list = [1, 2, 3, 2, 1];
-    check(list.lastIndexOf(2)).eq(3);
-    check(list.lastIndexOf(4)).eq(-1);
+    assertEQ(list.lastIndexOf(2), 3);
+    assertEQ(list.lastIndexOf(4), -1);
 }
 
 //-----------------------------------------------------------------------------
@@ -203,7 +203,7 @@ function testLastIndexOf() {
 
 function testMap() {
     var list = [1, 2, 3];
-    check(list.map(\x -> 2*x)).eq([2, 4, 6]);
+    assertEQ(list.map(\x -> 2*x), [2, 4, 6]);
 }
 
 //-----------------------------------------------------------------------------
@@ -211,8 +211,8 @@ function testMap() {
 
 function testPeekFirst() {
     var list = [1, 2, 3];
-    check(list.peekFirst()).eq(1);
-    check([].peekFirst()).eq(null);
+    assertEQ(list.peekFirst(), 1);
+    assertEQ([].peekFirst(), null);
 }
 
 //-----------------------------------------------------------------------------
@@ -220,8 +220,8 @@ function testPeekFirst() {
 
 function testPeekLast() {
     var list = [1, 2, 3];
-    check(list.peekLast()).eq(3);
-    check([].peekLast()).eq(null);
+    assertEQ(list.peekLast(), 3);
+    assertEQ([].peekLast(), null);
 }
 
 //-----------------------------------------------------------------------------
@@ -229,10 +229,10 @@ function testPeekLast() {
 
 function testRemove() {
     var list = [1, 2, 3];
-    check(list.remove(2)).eq(true);
-    check(list).eq([1, 3]);
+    assertEQ(list.remove(2), true);
+    assertEQ(list, [1, 3]);
 
-    check(list.remove(2)).eq(false);
+    assertEQ(list.remove(2), false);
 }
 
 //-----------------------------------------------------------------------------
@@ -240,10 +240,10 @@ function testRemove() {
 
 function testRemoveAll() {
     var list = [1, 2, 3];
-    check(list.removeAll([2])).eq(true);
-    check(list).eq([1, 3]);
+    assertEQ(list.removeAll([2]), true);
+    assertEQ(list, [1, 3]);
 
-    check(list.removeAll([4])).eq(false);
+    assertEQ(list.removeAll([4]), false);
 }
 
 //-----------------------------------------------------------------------------
@@ -251,11 +251,11 @@ function testRemoveAll() {
 
 function testRemoveAt() {
     var list = [1, 2, 3];
-    check(list.removeAt(1)).eq(2);
-    check(list).eq([1, 3]);
+    assertEQ(list.removeAt(1), 2);
+    assertEQ(list, [1, 3]);
 
-    checkCatch(\-> list.removeAt(-1))
-        .message("Expected 0 <= index < 2, got: Number '-1'.");
+    assertError(\-> list.removeAt(-1),
+        "Expected 0 <= index < 2, got: Number '-1'.");
 }
 
 //-----------------------------------------------------------------------------
@@ -263,10 +263,10 @@ function testRemoveAt() {
 
 function testRemoveFirst() {
     var list = [1, 2, 3];
-    check(list.removeFirst()).eq(1);
+    assertEQ(list.removeFirst(), 1);
 
-    checkCatch(\-> [].removeFirst())
-        .message("List is empty.");
+    assertError(\-> [].removeFirst(),
+        "List is empty.");
 }
 
 //-----------------------------------------------------------------------------
@@ -274,10 +274,10 @@ function testRemoveFirst() {
 
 function testRemoveLast() {
     var list = [1, 2, 3];
-    check(list.removeLast()).eq(3);
+    assertEQ(list.removeLast(), 3);
 
-    checkCatch(\-> [].removeLast())
-        .message("List is empty.");
+    assertError(\-> [].removeLast(),
+        "List is empty.");
 }
 
 //-----------------------------------------------------------------------------
@@ -285,7 +285,7 @@ function testRemoveLast() {
 
 function testReversed() {
     var list = [1, 2, 3];
-    check(list.reversed()).eq([3, 2, 1]);
+    assertEQ(list.reversed(), [3, 2, 1]);
 }
 
 //-----------------------------------------------------------------------------
@@ -293,16 +293,16 @@ function testReversed() {
 
 function testSet() {
     var list = [1, 2, 3];
-    check(list.set(1, "x")).eq(2);
-    check(list).eq([1, "x", 3]);
+    assertEQ(list.set(1, "x"), 2);
+    assertEQ(list, [1, "x", 3]);
 }
 
 //-----------------------------------------------------------------------------
 // size()
 
 function testSize() {
-    check([].size()).eq(0);
-    check([1,2,3].size()).eq(3);
+    assertEQ([].size(), 0);
+    assertEQ([1,2,3].size(), 3);
 }
 
 //-----------------------------------------------------------------------------
@@ -310,35 +310,35 @@ function testSize() {
 
 function testSorted_goodNoComp() {
     var list = [5, 4, 3, 2, 1];
-    check(list.sorted()).eq([1, 2, 3, 4, 5]);
+    assertEQ(list.sorted(), [1, 2, 3, 4, 5]);
 
     var list2 = ["e", "d", "c", "b", "a"];
-    check(list2.sorted()).eq(["a", "b", "c", "d", "e"]);
+    assertEQ(list2.sorted(), ["a", "b", "c", "d", "e"]);
 }
 
 function testSorted_goodComp() {
     var list = [5, 4, 3, 2, 1];
-    check(list.sorted(Joe.compare)).eq([1, 2, 3, 4, 5]);
+    assertEQ(list.sorted(Joe.compare), [1, 2, 3, 4, 5]);
 
     var list2 = ["e", "d", "c", "b", "a"];
-    check(list2.sorted(Joe.compare)).eq(["a", "b", "c", "d", "e"]);
+    assertEQ(list2.sorted(Joe.compare), ["a", "b", "c", "d", "e"]);
 }
 
 function testSorted_descending() {
     var list = [1,2,3,4,5];
-    check(list.sorted(\a,b -> -Joe.compare(a,b))).eq([5,4,3,2,1]);
+    assertEQ(list.sorted(\a,b -> -Joe.compare(a,b)), [5,4,3,2,1]);
 }
 
 function testSorted_mismatch() {
     var list = [5, "d", 3, "b", 1];
-    checkCatch(\-> list.sorted())
-        .message("Expected two strings or two numbers.");
+    assertError(\-> list.sorted(),
+        "Expected two strings or two numbers.");
 }
 
 function testSorted_badComp() {
     var list = [5, 4, 3, 2, 1];
-    checkCatch(\-> list.sorted(\a,b -> "abc"))
-        .message("Expected number, got: String 'abc'.");
+    assertError(\-> list.sorted(\a,b -> "abc"),
+        "Expected number, got: String 'abc'.");
 }
 
 
@@ -347,7 +347,7 @@ function testSorted_badComp() {
 
 function testSublist() {
     var list = [1, 2, 3, 4, 5];
-    check(list.sublist(1)).eq([2, 3, 4, 5]);
-    check(list.sublist(1, 3)).eq([2, 3]);
+    assertEQ(list.sublist(1), [2, 3, 4, 5]);
+    assertEQ(list.sublist(1, 3), [2, 3]);
 }
 

--- a/tests/type.joe.Map.joe
+++ b/tests/type.joe.Map.joe
@@ -2,14 +2,14 @@
 
 function testOf_empty() {
     var map = Map.of();
-    check(map).eq({:});
-    check(map.isEmpty()).isTrue();
+    assertEQ(map, {:});
+    assertT(map.isEmpty());
 }
 
 function testOf_entries() {
     var map = Map.of(#a, 1, #b, 2);
-    check(map.isEmpty()).isFalse();
-    check(map).eq({#a: 1, #b: 2});
+    assertF(map.isEmpty());
+    assertEQ(map, {#a: 1, #b: 2});
 }
 
 function testOf_odd() {
@@ -20,97 +20,97 @@ function testOf_odd() {
 
 function testInitializer() {
     var map1 = Map();
-    check(map1.isEmpty()).isTrue();
-    check(map1.size()).eq(0);
+    assertT(map1.isEmpty());
+    assertEQ(map1.size(), 0);
 
     var map2 = Map({#a: 1, #b: 2});
-    check(map2.isEmpty()).isFalse();
-    check(map2.size()).eq(2);
-    check(map2).eq({#a: 1, #b: 2});
+    assertF(map2.isEmpty());
+    assertEQ(map2.size(), 2);
+    assertEQ(map2, {#a: 1, #b: 2});
 }
 
 function testClear() {
     var map = {#a: 1};
     map.clear();
-    check(map.isEmpty()).isTrue();
-    check(map.size()).eq(0);
+    assertT(map.isEmpty());
+    assertEQ(map.size(), 0);
 }
 
 function testContainsKey() {
     var map = {#a: 1};
-    check(map.containsKey(#a)).isTrue();
-    check(map.containsKey(#b)).isFalse();
+    assertT(map.containsKey(#a));
+    assertF(map.containsKey(#b));
 }
 
 function testContainsValue() {
     var map = {#a: 1};
-    check(map.containsValue(1)).isTrue();
-    check(map.containsKey(2)).isFalse();
+    assertT(map.containsValue(1));
+    assertF(map.containsKey(2));
 }
 
 function testCopy() {
     var map = {#a: 1};
     var map2 = map.copy();
-    check(map2).eq(map);
+    assertEQ(map2, map);
     map2.clear();
-    check(map2 == map).isFalse();
+    assertF(map2 == map);
 }
 
 function testGet() {
     var map = {#a: 1};
-    check(map.get(#a)).eq(1);
-    check(map.get(#b)).isNull();
+    assertEQ(map.get(#a), 1);
+    assertEQ(map.get(#b), null);
 }
 
 function testGetOrDefault() {
     var map = {#a: 1};
-    check(map.getOrDefault(#a,0)).eq(1);
-    check(map.getOrDefault(#b,0)).eq(0);
+    assertEQ(map.getOrDefault(#a,0), 1);
+    assertEQ(map.getOrDefault(#b,0), 0);
 }
 
 function testIsEmpty() {
-    check({}.isEmpty()).isTrue();
-    check({#a: 1}.isEmpty()).isFalse();
+    assertT({}.isEmpty());
+    assertF({#a: 1}.isEmpty());
 }
 
 function testKeySet() {
     var map = {#a: 1, #b: 2};
-    check(map.keySet()).containsAll(#a, #b);
+    assertT(map.keySet().containsAll({#a, #b}));
 }
 
 function testPut() {
     var map = {:};
     map.put(#a, 1);
-    check(map).eq({#a: 1});
-    check(map.get(#a)).eq(1);
+    assertEQ(map, {#a: 1});
+    assertEQ(map.get(#a), 1);
 }
 
 function testPutAll() {
     var map1 = {#a: 1, #b: 2};
     var map2 = {#c: 3};
     map2.putAll(map1);
-    check(map2).eq({#a: 1, #b: 2, #c: 3});
+    assertEQ(map2, {#a: 1, #b: 2, #c: 3});
 }
 
 function testRemove() {
     var map = {#a: 1, #b: 2, #c: 3};
-    check(map.remove(#b)).eq(2);
-    check(map).eq({#a: 1, #c: 3});
-    check(map.remove(#d)).eq(null);
-    check(map).eq({#a: 1, #c: 3});
+    assertEQ(map.remove(#b), 2);
+    assertEQ(map, {#a: 1, #c: 3});
+    assertEQ(map.remove(#d), null);
+    assertEQ(map, {#a: 1, #c: 3});
 }
 
 function testSize() {
-    check({}.size()).eq(0);
-    check({#a: 1, #b: 2}.size()).eq(2);
+    assertEQ({}.size(), 0);
+    assertEQ({#a: 1, #b: 2}.size(), 2);
 }
 
 function testToString() {
-    check({#a: 1, #b: 2}.toString()).eq("{#a: 1, #b: 2}");
+    assertEQ({#a: 1, #b: 2}.toString(), "{#a: 1, #b: 2}");
 }
 
 function testValues() {
     var map = {#a: 1, #b: 2};
-    check(map.values()).containsAll(1, 2);
+    assertT(map.values().containsAll({1, 2}));
 }
 

--- a/tests/type.joe.Opaque.joe
+++ b/tests/type.joe.Opaque.joe
@@ -2,14 +2,14 @@
 
 function testName() {
     var name = Joe.typeOf(JoeTest.OPAQUE).name();
-    check(name).eq("OpaqueValue");
+    assertEQ(name, "OpaqueValue");
 }
 
 function testJavaName() {
     var name = Joe.typeOf(JoeTest.OPAQUE).javaName();
-    check(name).eq("com.wjduquette.joe.tools.test.TestPackage$OpaqueValue");
+    assertEQ(name, "com.wjduquette.joe.tools.test.TestPackage$OpaqueValue");
 }
 function testToString() {
     var string = JoeTest.OPAQUE.toString();
-    check(string).eq("com.wjduquette.joe.tools.test.TestPackage$OpaqueValue");
+    assertEQ(string, "com.wjduquette.joe.tools.test.TestPackage$OpaqueValue");
 }

--- a/tests/type.joe.RuleSet.joe
+++ b/tests/type.joe.RuleSet.joe
@@ -7,7 +7,7 @@ function testToString() {
     var rules = ruleset {
         Ancestor(x, y) :- Parent(x, y);
     };
-    check(rules.toString()).eq("""
+    assertEQ(rules.toString(), """
         ruleset {
             Ancestor(x, y) :- Parent(x, y);
         }
@@ -21,7 +21,7 @@ function testIsStratified_true() {
         Ancestor(x, y) :- Parent(x, y);
         Ancestor(x, y) :- Parent(x, z), Ancestor(z, y);
     };
-    check(rules.isStratified()).eq(true);
+    assertT(rules.isStratified());
 }
 
 // RuleSet::infer should always run successfully when no
@@ -34,7 +34,7 @@ function testInfer_noScriptedFacts() {
         Ancestor(x, y) :- Parent(x, z), Ancestor(z, y);
     };
     var results = rules.infer().map(Joe.stringify).sorted();
-    check(results).eq([
+    assertEQ(results, [
         "Fact(Ancestor, #anne, #bert)",
         "Fact(Ancestor, #anne, #clark)",
         "Fact(Ancestor, #bert, #clark)",
@@ -97,7 +97,7 @@ function testInfer_proxiedValue_ordered() {
     };
     var results = rules.infer(inputs).map(Joe.stringify).sorted();
 
-    check(results).eq([
+    assertEQ(results, [
         "Fact(Ancestor, #anne, #bert)",
         "Fact(Ancestor, #anne, #clark)",
         "Fact(Ancestor, #bert, #clark)",
@@ -118,7 +118,7 @@ function testInfer_proxiedValue_named() {
     };
     var results = rules.infer(inputs).map(Joe.stringify).sorted();
 
-    check(results).eq([
+    assertEQ(results, [
         "Fact(Ancestor, #anne, #bert)",
         "Fact(Ancestor, #anne, #clark)",
         "Fact(Ancestor, #bert, #clark)",
@@ -139,7 +139,7 @@ function testInfer_record_ordered() {
         Ancestor(x, y) :- Parent(x, z), Ancestor(z, y);
     };
     var results = rules.infer(inputs).map(Joe.stringify).sorted();
-    check(results).eq([
+    assertEQ(results, [
         "Fact(Ancestor, #anne, #bert)",
         "Fact(Ancestor, #anne, #clark)",
         "Fact(Ancestor, #bert, #clark)",
@@ -160,7 +160,7 @@ function testInfer_record_named() {
         Ancestor(x, y) :- Parent(p:x, c:z), Ancestor(z, y);
     };
     var results = rules.infer(inputs).map(Joe.stringify).sorted();
-    check(results).eq([
+    assertEQ(results, [
         "Fact(Ancestor, #anne, #bert)",
         "Fact(Ancestor, #anne, #clark)",
         "Fact(Ancestor, #bert, #clark)",
@@ -190,7 +190,7 @@ function testInfer_class_named() {
         Ancestor(x, y) :- Parent(p:x, c:z), Ancestor(z, y);
     };
     var results = rules.infer(inputs).map(Joe.stringify).sorted();
-    check(results).eq([
+    assertEQ(results, [
         "Fact(Ancestor, #anne, #bert)",
         "Fact(Ancestor, #anne, #clark)",
         "Fact(Ancestor, #bert, #clark)",

--- a/tests/type.joe.Set.joe
+++ b/tests/type.joe.Set.joe
@@ -2,93 +2,93 @@
 
 function testInitializer() {
     var set1 = {};
-    check(set1.isEmpty()).isTrue();
-    check(set1.size()).eq(0);
+    assertT(set1.isEmpty());
+    assertEQ(set1.size(), 0);
 
     var set2 = {#a, #b};
-    check(set2.isEmpty()).isFalse();
-    check(set2.size()).eq(2);
+    assertF(set2.isEmpty());
+    assertEQ(set2.size(), 2);
 }
 
 function testAdd() {
     var set = {};
-    check(set.add(#a)).isTrue();
-    check(set).eq({#a});
+    assertT(set.add(#a));
+    assertEQ(set, {#a});
 }
 
 function testAddAll() {
     var set1 = {#a, #b};
     var set2 = {#c};
-    check(set2.addAll(set1)).isTrue();
-    check(set2).eq({#a, #b, #c});
+    assertT(set2.addAll(set1));
+    assertEQ(set2, {#a, #b, #c});
 }
 
 function testClear() {
     var set = {#a};
     set.clear();
-    check(set.isEmpty()).isTrue();
-    check(set.size()).eq(0);
+    assertT(set.isEmpty());
+    assertEQ(set.size(), 0);
 }
 
 function testContains() {
     var set = {#a};
-    check(set.contains(#a)).isTrue();
-    check(set.contains(#b)).isFalse();
+    assertT(set.contains(#a));
+    assertF(set.contains(#b));
 }
 
 function testContainsAll() {
     var set = {#a, #b, #c, #d};
-    check(set.containsAll({#a, #c})).isTrue();
-    check(set.containsAll({#c, #e})).isFalse();
+    assertT(set.containsAll({#a, #c}));
+    assertF(set.containsAll({#c, #e}));
 }
 
 function testCopy() {
     var set = {#a};
     var set2 = set.copy();
-    check(set2).eq(set);
+    assertEQ(set2, set);
     set2.clear();
-    check(set2 == set).isFalse();
+    assertF(set2 == set);
 }
 
 function testFilter() {
     var set = {1, 2, 3, 4, 5};
     var filtered = set.filter(\x -> x > 3);
-    check(filtered).eq({4, 5});
+    assertEQ(filtered, {4, 5});
 }
 
 function testIsEmpty() {
-    check({}.isEmpty()).isTrue();
-    check({#a}.isEmpty()).isFalse();
+    assertT({}.isEmpty());
+    assertF({#a}.isEmpty());
 }
 
 function testMap() {
     var set = {1, 2, 3};
     var filtered = set.map(Joe.stringify);
-    check(filtered).eq({"1", "2", "3"});
+    assertEQ(filtered, {"1", "2", "3"});
 }
 
 function testRemove() {
     var set = {#a, #b, #c};
-    check(set.remove(#b)).isTrue();
-    check(set).eq({#a, #c});
-    check(set.remove(#d)).isFalse();
-    check(set).eq({#a, #c});
+    assertT(set.remove(#b));
+    assertEQ(set, {#a, #c});
+    assertF(set.remove(#d));
+    assertEQ(set, {#a, #c});
 }
 
 function testRemoveAll() {
     var set = {#a, #b, #c};
-    check(set.removeAll({#b})).isTrue();
-    check(set).eq({#a, #c});
+    assertT(set.removeAll({#b}));
+    assertEQ(set, {#a, #c});
 }
 
 function testSize() {
-    check({}.size()).eq(0);
-    check({#a, #b}.size()).eq(2);
+    assertEQ({}.size(), 0);
+    assertEQ({#a, #b}.size(), 2);
 }
 
 function testSorted_string() {
     var list = {"b", "c", "a", "d"}.sorted();
-    check(list).eq(["a", "b", "c", "d"]);
+    assertEQ(list, ["a", "b", "c", "d"]);
 }
 
 function testSorted_nonString_noComparator() {
@@ -102,9 +102,9 @@ function testSorted_nonString_comparator() {
     }
 
     var list = {#a, #b, #c, #d}.sorted(comp);
-    check(list).eq([#a, #b, #c, #d]);
+    assertEQ(list, [#a, #b, #c, #d]);
 }
 
 function testToString() {
-    check({#a, #b}.toString()).eq("{#a, #b}");
+    assertEQ({#a, #b}.toString(), "{#a, #b}");
 }

--- a/tests/type.joe.String.joe
+++ b/tests/type.joe.String.joe
@@ -1,155 +1,152 @@
 // String type tests
 
 function testCharAt() {
-    check("abc".charAt(0)).eq("a");
-    check("abc".charAt(2)).eq("c");
-    check("abc".charAt(2.9)).eq("c");
+    assertEQ("abc".charAt(0), "a");
+    assertEQ("abc".charAt(2), "c");
+    assertEQ("abc".charAt(2.9), "c");
 
     function bad1() { "abc".charAt(-1); }
     function bad2() { "abc".charAt(3); }
-    checkCatch(bad1).message("Expected 0 <= index < 3, got: Number '-1'.");
-    checkCatch(bad2).message("Expected 0 <= index < 3, got: Number '3'.");
+    assertError(bad1, "Expected 0 <= index < 3, got: Number '-1'.");
+    assertError(bad2, "Expected 0 <= index < 3, got: Number '3'.");
 }
 
 function testContains() {
-    check("abcdef".contains("bcd")).isTrue();
-    check("abcdef".contains("123")).isFalse();
+    assertT("abcdef".contains("bcd"));
+    assertF("abcdef".contains("123"));
 }
 
 function testEndsWith() {
-    check("abcdef".endsWith("def")).isTrue();
-    check("abcdef".endsWith("cde")).isFalse();
+    assertT("abcdef".endsWith("def"));
+    assertF("abcdef".endsWith("cde"));
 }
 
 function testEqualsIgnoreCase() {
-    check("abc".equalsIgnoreCase("ABC")).isTrue();
-    check("abc".equalsIgnoreCase("ABCD")).isFalse();
+    assertT("abc".equalsIgnoreCase("ABC"));
+    assertF("abc".equalsIgnoreCase("ABCD"));
 }
 
 function testIndent() {
-    check("abc".indent(2)).eq("  abc");
+    assertEQ("abc".indent(2), "  abc");
 }
 
 function testIndexOf() {
-    check("abcdefghi".indexOf("xyz")).eq(-1);
-    check("abcdefghi".indexOf("def")).eq(3);
+    assertEQ("abcdefghi".indexOf("xyz"), -1);
+    assertEQ("abcdefghi".indexOf("def"), 3);
 
-    check("abcabcabc".indexOf("bc", 2)).eq(4);
-    check("abcdeabcde".indexOf("c", 3, 6)).eq(-1);
+    assertEQ("abcabcabc".indexOf("bc", 2), 4);
+    assertEQ("abcdeabcde".indexOf("c", 3, 6), -1);
 }
 
 function testIsBlank() {
-    check("abc".isBlank()).isFalse();
-    check("   ".isBlank()).isTrue();
-    check("".isBlank()).isTrue();
+    assertF("abc".isBlank());
+    assertT("   ".isBlank());
+    assertT("".isBlank());
 }
 
 function testIsEmpty() {
-    check("abc".isEmpty()).isFalse();
-    check("   ".isEmpty()).isFalse();
-    check("".isEmpty()).isTrue();
+    assertF("abc".isEmpty());
+    assertF("   ".isEmpty());
+    assertT("".isEmpty());
 }
 
 function testJoin() {
-    check(String.join(",", [])).eq("");
-    check(String.join(",", ["a", "b"])).eq("a,b");
-    check(String.join(",", [1, 2])).eq("1,2");
+    assertEQ(String.join(",", []), "");
+    assertEQ(String.join(",", ["a", "b"]), "a,b");
+    assertEQ(String.join(",", [1, 2]), "1,2");
 }
 
 function testLastIndexOf() {
-    check("abcdefghi".lastIndexOf("xyz")).eq(-1);
-    check("abcabc".lastIndexOf("b")).eq(4);
+    assertEQ("abcdefghi".lastIndexOf("xyz"), -1);
+    assertEQ("abcabc".lastIndexOf("b"), 4);
 
-    check("abcabc".lastIndexOf("b", 3)).eq(1);
+    assertEQ("abcabc".lastIndexOf("b", 3), 1);
 }
 
 function testLength() {
-    check("abc".length()).eq(3);
+    assertEQ("abc".length(), 3);
 }
 
 function testLines() {
-    check(" abc ".lines())
-        .eq([" abc "]);
-    check(" abc \n def ".lines())
-        .eq([" abc ", " def "]);
+    assertEQ(" abc ".lines(), [" abc "]);
+    assertEQ(" abc \n def ".lines(), [" abc ", " def "]);
 }
 
 function testMatches() {
-    check("abc".matches("[a-z]+")).isTrue();
-    check("123".matches("[a-z]+")).isFalse();
+    assertT("abc".matches("[a-z]+"));
+    assertF("123".matches("[a-z]+"));
 }
 
 function testRepeat() {
-    check("abc".repeat(0)).eq("");
-    check("abc".repeat(1)).eq("abc");
-    check("abc".repeat(2)).eq("abcabc");
+    assertEQ("abc".repeat(0), "");
+    assertEQ("abc".repeat(1), "abc");
+    assertEQ("abc".repeat(2), "abcabc");
 
     function bad() { "abc".repeat(-1); }
 
-    checkCatch(bad)
-        .message("Expected non-negative count, got: Number '-1'.");
+    assertError(bad, "Expected non-negative count, got: Number '-1'.");
 }
 
 function testReplace() {
-    check("One cow, two cow.".replace("cow", "pig"))
-        .eq("One pig, two pig.");
+    assertEQ("One cow, two cow.".replace("cow", "pig"),
+        "One pig, two pig.");
 }
 
 function testReplaceAll() {
-    check("One cow, two cow.".replaceAll("[aeiou]", "*"))
-        .eq("On* c*w, tw* c*w.");
+    assertEQ("One cow, two cow.".replaceAll("[aeiou]", "*"),
+        "On* c*w, tw* c*w.");
 }
 
 function testReplaceFirst() {
-    check("One cow, two cow.".replaceFirst("[aeiou]", "*"))
-        .eq("On* cow, two cow.");
+    assertEQ("One cow, two cow.".replaceFirst("[aeiou]", "*"),
+        "On* cow, two cow.");
 }
 
 function testSplit() {
-    check("abc,def,ghi".split(","))
-    .eq(["abc", "def", "ghi"]);
+    assertEQ("abc,def,ghi".split(","),
+        ["abc", "def", "ghi"]);
 }
 
 function testSplitWithDelimiters() {
-    check("abc,def,ghi".splitWithDelimiters(","))
-    .eq(["abc", ",", "def", ",", "ghi"]);
+    assertEQ("abc,def,ghi".splitWithDelimiters(","),
+        ["abc", ",", "def", ",", "ghi"]);
 }
 
 function testStartsWith() {
-    check("abcdef".startsWith("abc")).isTrue();
-    check("abcdef".startsWith("bcd")).isFalse();
+    assertT("abcdef".startsWith("abc"));
+    assertF("abcdef".startsWith("bcd"));
 }
 
 function testStrip() {
-    check("  abc  ".strip()).eq("abc");
+    assertEQ("  abc  ".strip(), "abc");
 }
 
 function testStripIndent() {
-    check("   abc".stripIndent()).eq("abc");
+    assertEQ("   abc".stripIndent(), "abc");
 }
 
 function testStripLeading() {
-    check("  abc  ".stripLeading()).eq("abc  ");
+    assertEQ("  abc  ".stripLeading(), "abc  ");
 }
 
 function testStripTrailing() {
-    check("  abc  ".stripTrailing()).eq("  abc");
+    assertEQ("  abc  ".stripTrailing(), "  abc");
 }
 
 function testSubstring() {
     var txt = "abcdefghi";
-    check(txt.substring(3)).eq("defghi");
-    check(txt.substring(3, 6)).eq("def");
+    assertEQ(txt.substring(3), "defghi");
+    assertEQ(txt.substring(3, 6), "def");
 }
 
 function testToLowerCase() {
-    check("ABC".toUpperCase()).eq("abc");
+    assertEQ("ABC".toLowerCase(), "abc");
 }
 
-function testToLowerCase() {
-    check("AbC".toString()).eq("AbC");
+function testToString() {
+    assertEQ("AbC".toString(), "AbC");
 }
 
 function testToUpperCase() {
-    check("abc".toUpperCase()).eq("ABC");
+    assertEQ("abc".toUpperCase(), "ABC");
 }

--- a/tests/type.joe.TextBuilder.joe
+++ b/tests/type.joe.TextBuilder.joe
@@ -5,7 +5,7 @@
 
 function testEmpty() {
     var buff = TextBuilder();
-    check(buff.toString()).eq("");
+    assertEQ(buff.toString(), "");
 }
 
 function testAppend() {
@@ -13,7 +13,7 @@ function testAppend() {
     buff.append("a")
         .append("b")
         .append("c");
-    check(buff.toString()).eq("abc");
+    assertEQ(buff.toString(), "abc");
 }
 
 function testClear() {
@@ -22,7 +22,7 @@ function testClear() {
         .append("b")
         .append("c");
     buff.clear();
-    check(buff.toString()).eq("");
+    assertEQ(buff.toString(), "");
 }
 
 function testPrint() {
@@ -30,7 +30,7 @@ function testPrint() {
     buff.print("a")
         .print("b")
         .print("c");
-    check(buff.toString()).eq("abc");
+    assertEQ(buff.toString(), "abc");
 }
 
 function testPrintln() {
@@ -38,13 +38,13 @@ function testPrintln() {
     buff.println("a")
         .println("b")
         .println("c");
-    check(buff.toString()).eq("a\nb\nc\n");
+    assertEQ(buff.toString(), "a\nb\nc\n");
 }
 
 function testPrintf() {
     var buff = TextBuilder();
     buff.printf("%04d", 1);
-    check(buff.toString()).eq("0001");
+    assertEQ(buff.toString(), "0001");
 }
 
 //-----------------------------------------------------------------------------
@@ -53,7 +53,7 @@ function testPrintf() {
 function testFields() {
     var buff = TextBuilder();
     buff.name = "Fred";
-    check(buff.name).eq("Fred");
+    assertEQ(buff.name, "Fred");
 }
 
 //-----------------------------------------------------------------------------
@@ -70,7 +70,7 @@ function testSubclass_canExtend() {
     }
     var buff = Buff("+++ ");
     buff.fancy("abc");
-    check(buff.toString()).eq("+++ abc");
+    assertEQ(buff.toString(), "+++ abc");
 }
 
 function testSubclass_canUseSuper() {
@@ -81,5 +81,5 @@ function testSubclass_canUseSuper() {
     }
     var buff = Buff();
     buff.println("abc");
-    check(buff.toString()).eq("abc\n");
+    assertEQ(buff.toString(), "abc\n");
 }

--- a/tests/type.joe.Type.joe
+++ b/tests/type.joe.Type.joe
@@ -4,6 +4,6 @@
 // The Type type's own info
 
 function testName() {
-    check(Type.name()).eq("Type");
+    assertEQ(Type.name(), "Type");
 }
 

--- a/tests/type.joe.console.Path.joe
+++ b/tests/type.joe.console.Path.joe
@@ -2,42 +2,42 @@
 
 function testInitializer() {
     var p = Path("root/file.txt");
-    check(Joe.typeOf(p)).eq(Path);
-    check(p.getFileName()).eq(Path("file.txt"));
-    check(p.getParent()).eq(Path("root"));
-    check(p.getNameCount()).eq(2);
-    check(p.getName(0)).eq(Path("root"));
-    check(p.getName(1)).eq(Path("file.txt"));
-    check(p.isAbsolute()).isFalse();
-    check(p.toString()).eq("root/file.txt");
+    assertEQ(Joe.typeOf(p), Path);
+    assertEQ(p.getFileName(), Path("file.txt"));
+    assertEQ(p.getParent(), Path("root"));
+    assertEQ(p.getNameCount(), 2);
+    assertEQ(p.getName(0), Path("root"));
+    assertEQ(p.getName(1), Path("file.txt"));
+    assertF(p.isAbsolute());
+    assertEQ(p.toString(), "root/file.txt");
 
-    check(Path("root", "foo", "bar")).eq(Path("root/foo/bar"));
+    assertEQ(Path("root", "foo", "bar"), Path("root/foo/bar"));
 }
 
 function testCompare() {
     var p1 = Path("root/fileA.txt");
     var p2 = Path("root/fileB.txt");
 
-    check(Path.compare(p1, p1)).eq(0);
-    check(Path.compare(p1, p2)).eq(-1);
-    check(Path.compare(p2, p1)).eq(1);
+    assertEQ(Path.compare(p1, p1), 0);
+    assertEQ(Path.compare(p1, p2), -1);
+    assertEQ(Path.compare(p2, p1), 1);
 }
 
 function testEndsWith() {
     var p = Path("root/ball/fileA.txt");
-    check(p.endsWith(p.getFileName())).isTrue();
-    check(p.endsWith(p.getParent())).isFalse();
+    assertT(p.endsWith(p.getFileName()));
+    assertF(p.endsWith(p.getParent()));
 }
 
 function testNormalize() {
     var p = Path("root/foo/../bar/file.txt");
-    check(p.normalize()).eq(Path("root/bar/file.txt"));
+    assertEQ(p.normalize(), Path("root/bar/file.txt"));
 }
 
 function testRelativize() {
     var p1 = Path("/root/foo");
     var p2 = Path("/root/foo/bar/file.text");
-    check(p1.relativize(p2)).eq(Path("bar/file.text"));
+    assertEQ(p1.relativize(p2), Path("bar/file.text"));
 }
 
 function testResolve() {
@@ -45,28 +45,28 @@ function testResolve() {
     var p2 = Path("bar/file.text");
     var p3 = Path("/other/tree");
 
-    check(p1.resolve(p2)).eq(Path("/root/foo/bar/file.text"));
-    check(p1.resolve(p3)).eq(p3);
+    assertEQ(p1.resolve(p2), Path("/root/foo/bar/file.text"));
+    assertEQ(p1.resolve(p3), p3);
 }
 
 function testStartsWith() {
     var p = Path("root/ball/fileA.txt");
-    check(p.startsWith(p.getParent())).isTrue();
-    check(p.startsWith(p.getFileName())).isFalse();
+    assertT(p.startsWith(p.getParent()));
+    assertF(p.startsWith(p.getFileName()));
 }
 
 function testSubpath() {
     var p = Path("/root/foo/bar/file.text");
-    check(p.subpath(2)).eq(Path("bar/file.text"));
-    check(p.subpath(0, 2)).eq(Path("root/foo"));
+    assertEQ(p.subpath(2), Path("bar/file.text"));
+    assertEQ(p.subpath(0, 2), Path("root/foo"));
 }
 
 function testToAbsolute() {
     var p1 = Path(".");
     var p2 = p1.toAbsolutePath();
-    check(p2.isAbsolute()).isTrue();
+    assertT(p2.isAbsolute());
 
     // Absolute paths are host-dependent; just verify that the new
     // path begins with a "/", making it an absolute path.
-    check(p2.toString().startsWith("/")).isTrue();
+    assertT(p2.toString().startsWith("/"));
 }


### PR DESCRIPTION
This package revises the `joe.test` assertion API, simplifying the API and improving the output on error.

- `assertEquals` is now `assertEQ`, with better failure messages for collections.
- `assert{True,False}` is now `assert{T,F}`.
- Added `assertEmpty`.
- Touched up all failure messages
- The test suite (except for `pkg.joe.test.joe`, which tests `check`/`checkThrow`) now uses only `assert*` family.