### PR TITLE
`Tool` framework changes

### DIFF
--- a/lib/src/main/java/com/wjduquette/joe/app/App.java
+++ b/lib/src/main/java/com/wjduquette/joe/app/App.java
@@ -1,6 +1,7 @@
 package com.wjduquette.joe.app;
 
 import com.wjduquette.joe.tools.doc.DocTool;
+import com.wjduquette.joe.tools.test.TestWinTool;
 import com.wjduquette.joe.tools.win.WinTool;
 import com.wjduquette.joe.tools.test.TestTool;
 import com.wjduquette.joe.tools.ToolLauncher;
@@ -63,6 +64,7 @@ public class App {
             LibTool.INFO,
             DumpTool.INFO,
             TestTool.INFO,
+            TestWinTool.INFO,
             DocTool.INFO,
             WinTool.INFO
         ));

--- a/lib/src/main/java/com/wjduquette/joe/app/DumpTool.java
+++ b/lib/src/main/java/com/wjduquette/joe/app/DumpTool.java
@@ -20,19 +20,19 @@ public class DumpTool implements Tool {
     /**
      * Tool information for this tool, for use by the launcher.
      */
-    public static final ToolInfo INFO = new ToolInfo(
-        "dump",
-        "[options...] file.joe",
-        "Dumps information about the Joe script.",
-        """
-        Dumps compilation details for the script.  The options
-        are as follows:
-        
-        --code, -c   Dump the compiled byte-code (default)
-        --ast,  -a   Dump the Abstract Syntax Tree (AST)
-        """,
-        DumpTool::main
-    );
+    public static final ToolInfo INFO = ToolInfo.define()
+        .name("dump")
+        .argsig("[options...] file.joe")
+        .oneLiner("Dumps information about the Joe script.")
+        .launcher(DumpTool::main)
+        .help("""
+            Dumps compilation details for the script.  The options
+            are as follows:
+            
+            --code, -c   Dump the compiled byte-code (default)
+            --ast,  -a   Dump the Abstract Syntax Tree (AST)
+            """)
+        .build();
 
     //-------------------------------------------------------------------------
     // Constructor

--- a/lib/src/main/java/com/wjduquette/joe/app/LibTool.java
+++ b/lib/src/main/java/com/wjduquette/joe/app/LibTool.java
@@ -15,26 +15,26 @@ public class LibTool implements Tool {
     /**
      * Tool information for this tool, for use by the launcher.
      */
-    public static final ToolInfo INFO = new ToolInfo(
-        "lib",
-        "[options...]",
-        "Searches for local Joe packages.",
-        """
-        Searches the local disk for Joe packages.  By default it checks
-        the folders on the JOE_LIB_PATH, a colon-delimited list of
-        library folders.  Lists all found packages, along with any
-        errors encountered while searching.
-        
-        Options:
-        
-        --path path     Search the given path instead of JOE_LIB_PATH.
-        --check         Verifies that all packages found can be loaded.
-        
-        See the Joe User's Guide for information on how to create a
-        local package.
-        """,
-        LibTool::main
-    );
+    public static final ToolInfo INFO = ToolInfo.define()
+        .name("lib")
+        .argsig("[options...]")
+        .oneLiner("Searches for local Joe packages.")
+        .launcher(LibTool::main)
+        .help("""
+            Searches the local disk for Joe packages.  By default it checks
+            the folders on the JOE_LIB_PATH, a colon-delimited list of
+            library folders.  Lists all found packages, along with any
+            errors encountered while searching.
+            
+            Options:
+            
+            --path path     Search the given path instead of JOE_LIB_PATH.
+            --check         Verifies that all packages found can be loaded.
+            
+            See the Joe User's Guide for information on how to create a
+            local package.
+            """)
+        .build();
 
     //-------------------------------------------------------------------------
     // Constructor

--- a/lib/src/main/java/com/wjduquette/joe/app/NeroRunTool.java
+++ b/lib/src/main/java/com/wjduquette/joe/app/NeroRunTool.java
@@ -20,11 +20,12 @@ public class NeroRunTool implements Tool {
     /**
      * Tool information for this tool, for use by the launcher.
      */
-    public static final ToolInfo INFO = new ToolInfo(
-        "run",
-        "[options...] file.nero [file.nero...]",
-        "Executes Nero scripts.",
-        """
+    public static final ToolInfo INFO = ToolInfo.define()
+        .name("run")
+        .argsig("[options...] file.nero [file.nero...]")
+        .oneLiner("Executes Nero scripts.")
+        .launcher(NeroRunTool::main)
+        .help("""
         Nero is Joe's implementation of Datalog.  This tool executes Nero
         scripts and supports Nero debugging.
         
@@ -41,9 +42,9 @@ public class NeroRunTool implements Tool {
         
         --out filename, -o filename
             Writes the inferred facts to the given file.
-        """,
-        NeroRunTool::main
-    );
+        """)
+        .launcher(NeroRunTool::main)
+        .build();
 
     //-------------------------------------------------------------------------
     // Instance Variables

--- a/lib/src/main/java/com/wjduquette/joe/app/ReplTool.java
+++ b/lib/src/main/java/com/wjduquette/joe/app/ReplTool.java
@@ -21,11 +21,11 @@ public class ReplTool implements Tool {
     /**
      * Tool information for this tool, for use by the launcher.
      */
-    public static final ToolInfo INFO = new ToolInfo(
-        "repl",
-        "[options...]",
-        "Invokes a simple Joe REPL.",
-        """
+    public static final ToolInfo INFO =ToolInfo.define()
+        .name("repl")
+        .argsig("[options...]")
+        .oneLiner("Invokes a simple Joe REPL.")
+        .help("""
         Invokes the REPL.
         
         - To exit, press ^D.
@@ -56,9 +56,9 @@ public class ReplTool implements Tool {
         --debug, -d
             Enable debugging output.  This is mostly of use to
             the Joe maintainer.
-        """,
-        ReplTool::main
-    );
+        """)
+        .launcher(ReplTool::main)
+        .build();
 
     //-------------------------------------------------------------------------
     // Instance Variables

--- a/lib/src/main/java/com/wjduquette/joe/app/RunTool.java
+++ b/lib/src/main/java/com/wjduquette/joe/app/RunTool.java
@@ -21,11 +21,11 @@ public class RunTool implements Tool {
     /**
      * Tool information for this tool, for use by the launcher.
      */
-    public static final ToolInfo INFO = new ToolInfo(
-        "run",
-        "[options...] file.joe",
-        "Executes a Joe script.",
-        """
+    public static final ToolInfo INFO = ToolInfo.define()
+        .name("run")
+        .argsig("[options...] file.joe")
+        .oneLiner("Executes a Joe script.")
+        .help("""
         Executes the script.
         
         The tool searches for locally installed Joe packages on a user-provided
@@ -45,9 +45,9 @@ public class RunTool implements Tool {
         --debug, -d
             Enable debugging output.  This is mostly of use to
             the Joe maintainer.
-        """,
-        RunTool::main
-    );
+        """)
+        .launcher(RunTool::main)
+        .build();
 
     //-------------------------------------------------------------------------
     // Constructor

--- a/lib/src/main/java/com/wjduquette/joe/app/VersionTool.java
+++ b/lib/src/main/java/com/wjduquette/joe/app/VersionTool.java
@@ -13,15 +13,14 @@ public class VersionTool implements Tool {
     /**
      * Tool information for this tool, for use by the launcher.
      */
-    public static final ToolInfo INFO = new ToolInfo(
-        "version",
-        "",
-        "Prints Joe's version and build information.",
-        """
-        Prints Joe's version and build information.
-        """,
-        VersionTool::main
-    );
+    public static final ToolInfo INFO = ToolInfo.define()
+        .name("version")
+        .oneLiner("Prints Joe's version and build information.")
+        .launcher(VersionTool::main)
+        .help("""
+            Prints Joe's version and build information.
+            """)
+        .build();
 
     //-------------------------------------------------------------------------
     // Constructor

--- a/lib/src/main/java/com/wjduquette/joe/tools/ToolInfo.java
+++ b/lib/src/main/java/com/wjduquette/joe/tools/ToolInfo.java
@@ -15,8 +15,13 @@ public record ToolInfo(
     String argsig,
     String oneLiner,
     String help,
+    boolean isJavaFX,
     Consumer<String[]> launcher
 ) {
+    public static Builder define() {
+        return new Builder();
+    }
+
     /**
      * Prints the tool's usage string to standard output.
      * @param appName The application name
@@ -38,4 +43,96 @@ public record ToolInfo(
         System.out.println();
     }
 
+    public static class Builder {
+        //---------------------------------------------------------------------
+        // Instance variables
+
+        String name = null;
+        String argsig = "";
+        String oneLiner = "";
+        String help = "";
+        boolean isJavaFX = false;
+        Consumer<String[]> launcher = null;
+
+        //---------------------------------------------------------------------
+        // Constructor
+
+        public Builder() {
+            // Nothing to do
+        }
+
+        //---------------------------------------------------------------------
+        // API
+
+        /**
+         * Sets the tool's name.
+         * @param name The name
+         * @return The builder
+         */
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        /**
+         * Sets the tool's argument signature.
+         * @param sig The signature
+         * @return The builder
+         */
+        public Builder argsig(String sig) {
+            this.argsig = sig;
+            return this;
+        }
+
+        /**
+         * Sets the tool's one-line description
+         * @param oneLiner The description
+         * @return The builder
+         */
+        public Builder oneLiner(String oneLiner) {
+            this.oneLiner = oneLiner;
+            return this;
+        }
+
+        /**
+         * Sets the tool's help text.
+         * @param help The text
+         * @return The builder
+         */
+        public Builder help(String help) {
+            this.help = help;
+            return this;
+        }
+
+        /**
+         * Sets whether this is a non-GUI tool or a JavaFX tool.
+         * @param flag true or false
+         * @return The builder
+         */
+        public Builder javafx(boolean flag) {
+            this.isJavaFX = flag;
+            return this;
+        }
+
+        /**
+         * Sets the launcher function.
+         * @param launcher The launcher
+         * @return The builder
+         */
+        public Builder launcher(Consumer<String[]> launcher ) {
+            this.launcher = launcher;
+            return this;
+        }
+
+        public ToolInfo build() {
+            return new ToolInfo(
+                name,
+                argsig,
+                oneLiner,
+                help,
+                isJavaFX,
+                launcher
+            );
+        }
+    }
 }

--- a/lib/src/main/java/com/wjduquette/joe/tools/ToolLauncher.java
+++ b/lib/src/main/java/com/wjduquette/joe/tools/ToolLauncher.java
@@ -3,6 +3,8 @@
  */
 package com.wjduquette.joe.tools;
 
+import javafx.application.Platform;
+
 import java.util.*;
 
 /**
@@ -82,13 +84,26 @@ public class ToolLauncher {
         var subcommand = argq.poll();
 
         var tool = tools.get(subcommand);
+        String[] argv = rest(args);
 
         if (tool != null) {
-            tool.launcher().accept(rest(args));
+            if (tool.isJavaFX()) {
+                Platform.startup(() -> launchJavaFX(tool, argv));
+            } else {
+                tool.launcher().accept(argv);
+            }
         } else if (subcommand.equals("help")) {
             showHelp(argq);
         } else {
             showFailure(subcommand);
+        }
+    }
+
+    private void launchJavaFX(ToolInfo tool, String[] args) {
+        Platform.setImplicitExit(false);
+        tool.launcher().accept(args);
+        if (!Platform.isImplicitExit()) {
+            System.exit(0);
         }
     }
 

--- a/lib/src/main/java/com/wjduquette/joe/tools/doc/DocTool.java
+++ b/lib/src/main/java/com/wjduquette/joe/tools/doc/DocTool.java
@@ -20,21 +20,21 @@ public class DocTool implements Tool {
     /**
      * Tool information for this tool, for use by the launcher.
      */
-    public static final ToolInfo INFO = new ToolInfo(
-        "doc",
-        "[options...]",
-        "Generates documentation from JoeDoc comments.",
-        """
-        The 'joe doc' tool scans a project's Java and Joe source for
-        JoeDoc comments and produces API documentation suitable for
-        inclusion in an mdBook document.
-        
-        Options:
-        
-        --verbose, -v    Enable verbose output.
-        """,
-        DocTool::main
-    );
+    public static final ToolInfo INFO = ToolInfo.define()
+        .name("doc")
+        .argsig("[options...]")
+        .oneLiner("Generates documentation from JoeDoc comments.")
+        .launcher(DocTool::main)
+        .help("""
+            The 'joe doc' tool scans a project's Java and Joe source for
+            JoeDoc comments and produces API documentation suitable for
+            inclusion in an mdBook document.
+            
+            Options:
+            
+            --verbose, -v    Enable verbose output.
+            """)
+        .build();
 
     /**
      * The set of file types normally scanned for doc comments.

--- a/lib/src/main/java/com/wjduquette/joe/tools/test/TestTool.java
+++ b/lib/src/main/java/com/wjduquette/joe/tools/test/TestTool.java
@@ -19,11 +19,12 @@ public class TestTool implements Tool {
     /**
      * Tool information for this tool, for use by the launcher.
      */
-    public static final ToolInfo INFO = new ToolInfo(
-        "test",
-        "options... testFile.joe...",
-        "Executes Joe tests.",
-        """
+    public static final ToolInfo INFO = ToolInfo.define()
+        .name("test")
+        .argsig("options... testFile.joe...")
+        .oneLiner("Executes Joe tests.")
+        .launcher(TestTool::main)
+        .help("""
         Executes a test suite consisting of one or more Joe test scripts,
         accumulating the results.
         
@@ -55,10 +56,8 @@ public class TestTool implements Tool {
         NOTE: `joe test` does not load packages from the JOE_LIB_PATH, as it
         assumes that the user is testing the library from within a code
         repository, not as installed for general use.
-        
-        """,
-        TestTool::main
-    );
+        """)
+        .build();
 
     //-------------------------------------------------------------------------
     // Instance Variables

--- a/lib/src/main/java/com/wjduquette/joe/tools/test/TestWinTool.java
+++ b/lib/src/main/java/com/wjduquette/joe/tools/test/TestWinTool.java
@@ -1,0 +1,297 @@
+package com.wjduquette.joe.tools.test;
+
+import com.wjduquette.joe.*;
+import com.wjduquette.joe.app.App;
+import com.wjduquette.joe.tools.Tool;
+import com.wjduquette.joe.tools.ToolInfo;
+import com.wjduquette.joe.win.WinPackage;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The implementation of the `joe test` tool.
+ */
+public class TestWinTool implements Tool {
+    /**
+     * Tool information for this tool, for use by the launcher.
+     */
+    public static final ToolInfo INFO = ToolInfo.define()
+        .name("testwin")
+        .argsig("options... testFile.joe...")
+        .oneLiner("Executes Joe tests in the JavaFX context.")
+        .javafx(true)
+        .launcher(TestWinTool::main)
+        .help("""
+        Executes a test suite consisting of one or more Joe test scripts
+        in the JavaFX context, accumulating the results.
+        
+        Options:
+        
+        --libpath path, --l path
+           Sets the library path to the given path.
+        --clark, -c
+            Use the "Clark" byte-engine (default)
+        --walker, -w
+            Use the "Walker" AST-walker engine.
+        --verbose, -v
+            Enable verbose output.
+        
+        Test Scripts
+        
+        A test script is a Joe script containing one or more no-argument Joe
+        functions with names beginning with "test".  A test fails if it
+        throws a Joe AssertError, either via Joe's assert statement or by
+        using one of the test checkers defined by the test tool.  See
+        the Joe User's Guide for more details.
+        
+        Testing Joe Libraries
+        
+        If the --libpath option is used, the tool searches for
+        Joe packages on the given library path, which must be a colon-delimited
+        list of folder paths.
+        
+        NOTE: `joe test` does not load packages from the JOE_LIB_PATH, as it
+        assumes that the user is testing the library from within a code
+        repository, not as installed for general use.
+        """)
+        .build();
+
+    //-------------------------------------------------------------------------
+    // Instance Variables
+
+    private String engineType = Joe.CLARK;
+    private String libPath = null;
+    private PackageFinder finder = null;
+    private boolean verbose = false;
+    private final List<String> testScripts = new ArrayList<>();
+    private int loadErrorCount = 0;
+    private int successCount = 0;
+    private int skipCount = 0;
+    private int failureCount = 0;
+    private int errorCount = 0;
+
+    //-------------------------------------------------------------------------
+    // Constructor
+
+    /**
+     * Creates the tool.
+     */
+    public TestWinTool() {
+        // Nothing to do
+    }
+
+    //-------------------------------------------------------------------------
+    // Execution
+
+    public ToolInfo toolInfo() {
+        return INFO;
+    }
+
+    private void run(String[] args) {
+        // FIRST, parse the command line.
+        var argq = new ArrayDeque<>(List.of(args));
+
+        if (argq.isEmpty()) {
+            printUsage(App.NAME);
+            System.exit(1);
+        }
+
+        while (!argq.isEmpty()) {
+            var arg = argq.poll();
+
+            switch (arg) {
+                case "--libpath", "-l" -> libPath = toOptArg(arg, argq);
+                case "--clark", "-c" -> engineType = Joe.CLARK;
+                case "--walker", "-w" -> engineType = Joe.WALKER;
+                case "-v", "--verbose" -> verbose = true;
+                default -> testScripts.add(arg);
+            }
+        }
+
+        // FIRST, find any local packages
+        if (libPath != null) {
+            finder = PackageFinder.find(libPath);
+        }
+
+        // NEXT, run the tests.
+        var startTime = Instant.now();
+        System.out.println("Joe " + App.getVersion() + " (" +
+            engineType + " engine)");
+        for (var path : testScripts) {
+            runTest(path);
+        }
+        var endTime = Instant.now();
+        var duration = Duration.between(startTime, endTime).toMillis() / 1000.0;
+
+        System.out.printf("Run-time: %.3f seconds\n", duration);
+
+        // NEXT, print the final results
+        var total = successCount + skipCount + failureCount + errorCount;
+        println();
+        System.out.printf("Successes  %5d\n", successCount);
+        System.out.printf("Skipped    %5d\n", skipCount);
+        System.out.printf("Failures   %5d\n", failureCount);
+        System.out.printf("Errors     %5d\n", errorCount);
+        System.out.println("---------- -----");
+        System.out.printf("Total      %5d\n", total);
+
+        if (loadErrorCount != 0) {
+            println("\n*** " + loadErrorCount + " test file(s) failed to load.");
+        }
+
+        if (successCount == total && loadErrorCount == 0) {
+            println("\nALL TESTS PASS");
+        }
+        System.exit(0);
+    }
+
+    private void runTest(String scriptPath) {
+        if (verbose) {
+            println("\nRunning: " + scriptPath);
+        }
+
+        // NEXT, configure the engine.
+        var joe = new Joe(engineType);
+        joe.installPackage(new TestPackage(engineType));
+        joe.installPackage(new WinPackage(new Stage(), new VBox()));
+        if (finder != null) {
+            joe.registerPackages(finder);
+        }
+
+        // Only print script output if the verbose flag is set.
+        joe.setOutputHandler(this::testPrinter);
+
+        // FIRST, load the script.
+        try {
+            joe.runFile(scriptPath);
+        } catch (IOException ex) {
+            println("Could not read script: " + scriptPath +
+                "\n*** " + ex.getMessage());
+            ++loadErrorCount;
+        } catch (SyntaxError ex) {
+            System.out.println(ex.getErrorReport());
+            System.out.println(ex.getMessage());
+            ++loadErrorCount;
+        } catch (JoeError ex) {
+            System.out.print("*** Error in script: ");
+            println(ex.getJoeStackTrace());
+            ++loadErrorCount;
+        }
+
+        // NEXT, execute its tests.
+        var tests = joe.getVariableNames().stream()
+            .filter(name -> name.startsWith("test"))
+            .toList();
+
+        if (tests.isEmpty()) {
+            println("***  No tests in: " + scriptPath);
+            return;
+        }
+
+        if (verbose) {
+            println();
+            runVerbosely(joe, tests);
+        } else {
+            runQuietly(joe, scriptPath, tests);
+        }
+    }
+
+    private void testPrinter(String message) {
+        if (verbose) {
+            System.out.print(message);
+        }
+    }
+
+    private void runVerbosely(Joe joe, List<String> tests) {
+        for (var test : tests) {
+            var callable = joe.getVariable(test);
+            if (!joe.isCallable(callable)) {
+                continue;
+            }
+
+            println("+++ " + test);
+
+            try {
+                joe.call(callable);
+                ++successCount;
+            } catch (SkipError ex) {
+                println("  SKIPPED: " + ex.getMessage());
+                ++skipCount;
+            } catch (AssertError ex) {
+                println("  FAILED:\n" + ex.getJoeStackTrace().indent(4));
+                ++failureCount;
+            } catch (JoeError ex) {
+                println("  ERROR:\n" + ex.getJoeStackTrace().indent(4));
+                ++errorCount;
+            }
+        }
+    }
+
+    private void runQuietly(Joe joe, String scriptPath, List<String> tests) {
+        for (var test : tests) {
+            var callable = joe.getVariable(test);
+            if (!joe.isCallable(callable)) {
+                continue;
+            }
+
+            String result;
+            Exception error;
+
+            try {
+                joe.call(callable);
+                ++successCount;
+                result = null;
+                error = null;
+            } catch (SkipError ex) {
+                ++skipCount;
+                result = "SKIPPED";
+                error = ex;
+            } catch (AssertError ex) {
+                ++failureCount;
+                result = "FAILED";
+                error = ex;
+            } catch (JoeError ex) {
+                ++errorCount;
+                result = "ERROR";
+                error = ex;
+            }
+
+            if (error != null) {
+                System.out.printf("%-8s %s %s\n%s\n", result + ":", scriptPath,
+                    test, error.getMessage().indent(4));
+            }
+        }
+    }
+
+    //-------------------------------------------------------------------------
+    // SkipException
+
+    /**
+     * An exception used by the test API's "skip()" function.
+     */
+    public static class SkipError extends JoeError {
+        /**
+         * Creates the exception.
+         * @param message The skip message.
+         */
+        public SkipError(String message) { super(message); }
+    }
+
+    //-------------------------------------------------------------------------
+    // Main
+
+    /**
+     * The tool's main routine.
+     * @param args The command line arguments.
+     */
+    public static void main(String[] args) {
+        new TestWinTool().run(args);
+    }
+}


### PR DESCRIPTION
This pull request revises the `com.wjduquette.joe.tools` framework so that
it is no longer necessary to use `FXTool` for JavaFX-based tools.  Instead,
`ToolInfo` now has a `isJavaFX` flag; if this is true, the tool's launcher
function is invoked using the JavaFX `Platform.startup()` method.  It is then
up to the tool to create a `Stage` if it wants one, and to call
`Platform.setImplicitExit(true)` if it wants the tool to remain running until
the last window closes.

In addition, it defines a new tool, `joe testwin`, that runs Joe tests in
the JavaFX context.