### PR TITLE
Pattern and Nero predicate changes

### DIFF
--- a/jug/src/changes.md
+++ b/jug/src/changes.md
@@ -15,8 +15,12 @@ scripts.
     terminated early and mysteriously.
   - The corruption has been fixed, and such methods work properly.
 - Joe Language
-    - Restored `@` as the property reference operator in instance
+  - Restored `@` as the property reference operator in instance
       methods, replacing `.`, which proved to be highly confusing in practice.
+  - `{:}` is no longer a valid map pattern.
+    - It looks like it should match the empty map only, but to be consistent
+      with other map patterns it matches any map.  This is confusing, and there
+      are better ways to check for empty maps.
 - Nero Language
     - Facts are now simply ordered or unordered.
     - Named atoms used in axioms and rule heads can create ordered facts

--- a/jug/src/nero/builtin_predicates.md
+++ b/jug/src/nero/builtin_predicates.md
@@ -15,14 +15,13 @@ of Nero's built-in predicates start with a lowercase letter.
 
 Nero provides the following built-in predicates.
 
-- [`member/item, collection`](#memberitem-collection) (`INOUT`, `IN`)
-- [`indexedMember/index, item, list`](#indexedmemberindex-item-list) (`INOUT`, `INOUT`, `IN`)
-- [`keyedMember/key, value, map`](#keyedmemberkey-value-map) (`INOUT`, `INOUT`, `IN`)
+- [`has/collection, item`](#hascollection-item) (`IN`, `INOUT`)
+- [`at/collection, key, item`](#atcollection-key-item) (`IN`, `INOUT`, `INOUT`)
 - [`mapsTo/f, a, b`](#mapstof-a-b) (`IN`, `IN`, `INOUT`)
 
-## `member/item, collection`
+## `has/collection, item`
 
-The `member/item, collection` predicate matches an *item* (`INOUT`) 
+The `has/collection, item` predicate matches an *item* (`INOUT`) 
 in a *collection* (`IN`), where the *collection* is presumably
 a list or a set. If the *collection* is not a list or set then
 the predicate will not match.
@@ -46,18 +45,18 @@ We want to write a rule that flags whether a person has a hat or not:
 
 ```nero
 define WearsHat/owner;
-WearsHat(id) :- Owner(id, stuff), member(#hat, stuff);
+WearsHat(id) :- Owner(id, stuff), has(stuff, #hat);
 ```
 
-When `id` is `#joe`, the `member` predicate takes the collection, `stuff`, and 
+When `id` is `#joe`, the `has` predicate takes the collection, `stuff`, and 
 breaks it into the following set of temporary facts:
 
-- `member(#hat, stuff)`
-- `member(#boots, stuff)`
-- `member(#truck, stuff)`
+- `has(stuff, #hat)`
+- `has(stuff, #boots)`
+- `has(stuff, #truck)`
 
 The predicate is then matched against these facts in the usual way, and 
-in particular matches the fact `member(#hat, stuff)`.  The rule matches,
+in particular matches the fact `has(stuff, #hat)`.  The rule matches,
 and so we infer `WearsHat(#joe)`.
 
 Alternatively, we might want to disaggregate a person's belongings into
@@ -65,7 +64,7 @@ a new relation, `Owns/id,item`.  We can do that in this way:
 
 ```nero
 define Owns/owner,item;
-Owns(id, item) :- Owner(id, stuff), member(item, stuff);
+Owns(id, item) :- Owner(id, stuff), has(stuff, item);
 ```
 
 Because `item` isn't bound to any previous value, the predicate will match
@@ -78,17 +77,20 @@ and we will end up with these new facts:
 
 In database terms, we have just put Joe's belongings into *normal form*.
 
-## `indexedMember/index, item, list`
+## `at/collection, key, item`
 
-The `indexedMember/index, item, list` predicate matches an *item* (`INOUT`)
-and its *index* (`INOUT`) within a *list* (`IN`).
-If the *list* is something other than a `List` then the predicate
-will not match.
+The `at/collection, key, item` predicate matches an *item* (`INOUT`)
+at its *key* (`INOUT`) within a *collection* (`IN`).  If the *collection*
+is a list, the *key* will be the index of the *item* within the list; if
+the *collection* is a map, the *key* will be the map key.  If the *collection*
+is anything else, the predicate will not match.
 
-Like `member/item, collection`, the predicate can test for membership
-or disaggregate the list into individual facts.  When used for the
-latter purpose, the *index* allows the new facts to preserve the 
-ordering of the items in the original list.
+Like `has/collection, item`, the predicate can test for membership
+or disaggregate the collection into individual facts.  
+
+When used to disaggregate a list, the *key* is the index of the item in
+the list, which allows the individual facts to preserve the ordering of the 
+items in the original list.
 
 For example, this program
 
@@ -97,7 +99,7 @@ define Owner/id, belongings;
 Owner(#joe, [#hat, #boots, #truck]);
 
 define Owns/owner,index,item;
-Owns(id, index, item) :- Owner(id, stuff), indexedMember(index, item, stuff);
+Owns(id, index, item) :- Owner(id, stuff), at(stuff, index, item);
 ```
 
 yields these facts:
@@ -107,27 +109,17 @@ yields these facts:
 - `Owns(#joe, 2, #truck)`
 
 **Note:** the `indexedList(index, item)` 
-[aggregation function](aggregation_functions.md) can reaggregate the times
+[aggregation function](aggregation_functions.md) can than reaggregate the items
 back into the original list.
 
-## `keyedMember/key, value, map`
-
-The `keyedMember/key, value, map` predicate matches a 
-*key* (`INOUT`), *value* (`INOUT`) pair within a *map* (`IN`).
-If the *map* is something other than a `Map` value the predicate will
-not match.
-
-Like `member/item, collection`, the predicate can test for membership
-or disaggregate the map into individual facts.  
-
-For example, this program
+Similar, this program disaggregates a map:
 
 ```nero
 define Owner/id, belongings;
 Owner(#joe, {#head: #hat, #feet: #boots, #body: #duster});
 
 define Owns/owner,place,item;
-Owns(id, place, item) :- Owner(id, stuff), keyedMember(place, item, stuff);
+Owns(id, place, item) :- Owner(id, stuff), at(stuff, place, item);
 ```
 
 yields these facts:

--- a/jug/src/nero/builtin_predicates.md
+++ b/jug/src/nero/builtin_predicates.md
@@ -18,6 +18,7 @@ Nero provides the following built-in predicates.
 - [`has/collection, item`](#hascollection-item) (`IN`, `INOUT`)
 - [`at/collection, key, item`](#atcollection-key-item) (`IN`, `INOUT`, `INOUT`)
 - [`mapsTo/f, a, b`](#mapstof-a-b) (`IN`, `IN`, `INOUT`)
+- [`size/collection, number`](#sizecollection-number) (`IN`, `INOUT`)
 
 ## `has/collection, item`
 
@@ -178,3 +179,28 @@ functions using Nero's Joe and Java APIs.
 
 - `#str2num`
   - Maps numeric string *a* to number *b*.
+
+## `size/collection, number`
+
+The `size/collection, number` predicate generates or matches the size (`INOUT`)
+of a *collection* (`IN`), where the *collection* is a list, set, or map. 
+If the *collection* is none of the above, the predicate will not match.
+
+For example, the following rule gets the number of items owned by each person.
+
+```nero
+define transient Owner/id,list;
+Owner(#joe, [#hat, #boots, #truck]);
+Owner(#bob, {#desk: #pc, #garage: #corvette});
+
+define Count/id,number;
+Count(id, number) :- Owner(id, list), size(list, number);
+```
+
+This yields
+
+```
+define Count/id,number;
+Count(#bob, 2);
+Count(#joe, 3);
+```

--- a/jug/src/patterns.md
+++ b/jug/src/patterns.md
@@ -249,6 +249,15 @@ var ($x: value} = someMap;                   // value = someMap.get(x)
 var {#a: [a, b, c], #b: x} = someMap;
 ```
 
+Map patterns mimic normal map syntax, and so it seems that the empty map,
+`{:}`, should be a valid map pattern. To be consistent with other map patterns,
+`{:}` should match every map, because every key that's present in the pattern
+is present in the target map.  But this is not very useful, and experience
+shows that users expect `{:}` to match the empty map only.  But that is
+inconsistent with other map patterns. `{:}` has therefore
+been excluded as a map pattern in order to prevent confusion.  There are
+other ways to test whether a value is a map and whether a map is empty.
+
 ## Type-Name Patterns
 
 A type-name pattern matches the target value's type by name.  It is

--- a/lib/src/main/java/com/wjduquette/joe/nero/Fact.java
+++ b/lib/src/main/java/com/wjduquette/joe/nero/Fact.java
@@ -26,10 +26,19 @@ public final class Fact {
      * @param fields The field values
      */
     public Fact(String relation, List<String> names, List<Object> fields) {
-        this.shape = new Shape(relation, names);
+        this(new Shape(relation, names), fields);
+    }
+
+    /**
+     * Creates a new ordered fact given the inputs.
+     * @param shape The shape
+     * @param fields The field values
+     */
+    public Fact(Shape shape, List<Object> fields) {
+        this.shape = shape;
         this.fields = Collections.unmodifiableList(new ArrayList<>(fields));
 
-        if (names.size() != fields.size()) {
+        if (shape.names().size() != fields.size()) {
             throw new IllegalArgumentException("names.size != fields.size");
         }
 

--- a/lib/src/main/java/com/wjduquette/joe/nero/RuleEngine.java
+++ b/lib/src/main/java/com/wjduquette/joe/nero/RuleEngine.java
@@ -49,7 +49,11 @@ public class RuleEngine {
         HAS("has", List.of(IN, INOUT), List.of("collection", "item")),
 
         /** {@code mapsTo/f, a, b} */
-        MAPS_TO("mapsTo", List.of(IN, IN, INOUT), List.of("f", "a", "b"));
+        MAPS_TO("mapsTo", List.of(IN, IN, INOUT), List.of("f", "a", "b")),
+
+        /** {@code size/collection, number} */
+        SIZE("size", List.of(IN, INOUT), List.of("collection", "number"));
+
 
         //---------------------------------------------------------------------
         // Metadata
@@ -176,9 +180,10 @@ public class RuleEngine {
         this.ruleset = ruleset;
         this.knownFacts = db;
         this.builtIns = Map.of(
-            BuiltIn.AT.relation(),             this::_at,
-            BuiltIn.HAS.relation(),            this::_has,
-            BuiltIn.MAPS_TO.relation(),        this::_mapsTo
+            BuiltIn.AT.relation(),          this::_at,
+            BuiltIn.HAS.relation(),         this::_has,
+            BuiltIn.MAPS_TO.relation(),     this::_mapsTo,
+            BuiltIn.SIZE.relation(),        this::_size
         );
 
         // Define the predefined mapsTo/f,a,b mappers
@@ -682,6 +687,21 @@ public class RuleEngine {
         facts.add(new Fact(BuiltIn.MAPS_TO.shape(), List.of(f, a, b)));
         return facts;
     }
+
+    // size/collection,number
+    private Set<Fact> _size(BindingContext bc, Atom atom) {
+        var coll = extractVar(bc, atom, 0);
+        var facts = new HashSet<Fact>();
+
+        if (coll instanceof Collection<?> c) {
+            facts.add(new Fact(BuiltIn.SIZE.shape(), List.of(c, (double)c.size())));
+        } else if (coll instanceof Map<?,?> m) {
+            facts.add(new Fact(BuiltIn.SIZE.shape(), List.of(m, (double)m.size())));
+        }
+
+        return facts;
+    }
+
 
     private Object extractVar(BindingContext bc, Atom atom, int index) {
         assert atom instanceof ListAtom;

--- a/lib/src/main/java/com/wjduquette/joe/nero/RuleEngine.java
+++ b/lib/src/main/java/com/wjduquette/joe/nero/RuleEngine.java
@@ -38,50 +38,41 @@ public class RuleEngine {
         Set<Fact> compute(BindingContext bc, Atom builtIn);
     }
 
-    /**
-     * Information about a built-in, as required by the NeroParser
-     * @param shape The shape
-     * @param modes The mode for each term.
-     */
-    public record BuiltIn(Shape shape, List<TermMode> modes) {}
+    public enum BuiltIn {
+        MEMBER("member", List.of(INOUT, IN), List.of("item", "collection")),
+        INDEXED_MEMBER("indexedMember", List.of(INOUT, INOUT, IN),
+            List.of("index", "item", "list")),
+        KEYED_MEMBER("keyedMember", List.of(INOUT, INOUT, IN),
+            List.of("key", "value", "map")),
+        MAPS_TO("mapsTo", List.of(IN, IN, INOUT), List.of("f", "a", "b"));
 
+        //---------------------------------------------------------------------
+        // Metadata
+
+        private final Shape shape;
+        private final List<TermMode> modes;
+
+        BuiltIn(String name, List<TermMode> modes, List<String> fields) {
+            this.shape = new Shape(name, fields);
+            this.modes = modes;
+        }
+
+        public String relation()      { return shape.relation(); }
+        public Shape shape()          { return shape; }
+        public List<TermMode> modes() { return modes; }
+    }
+
+    // A map of built-ins for each lookup.
     private static final Map<String,BuiltIn> BUILT_INS = new HashMap<>();
 
-    /** Name of the "member" built-in predicate. */
-    public static final String MEMBER = "member";
-
-    /** Name of the "indexedMember" built-in predicate. */
-    public static final String INDEXED_MEMBER = "indexedMember";
-
-    /** Name of the "keyedMember" built-in predicate. */
-    public static final String KEYED_MEMBER = "keyedMember";
-
-    /** Name of the "mapsTo" built-in predicate. */
-    public static final String MAPS_TO = "mapsTo";
+    static {
+        for (var value : BuiltIn.values()) {
+            BUILT_INS.put(value.relation(), value);
+        }
+    }
 
     /** Name of the "str2num" mapper function. */
     public static final Keyword STR2NUM = new Keyword("str2num");
-
-    static {
-        builtIn(MEMBER,
-            List.of(INOUT, IN), List.of("item", "collection"));
-        builtIn(INDEXED_MEMBER,
-            List.of(INOUT, INOUT, IN), List.of("index", "item", "list"));
-        builtIn(KEYED_MEMBER,
-            List.of(INOUT, INOUT, IN), List.of("key", "value", "map"));
-        builtIn(MAPS_TO,
-            List.of(IN, IN, INOUT), List.of("f", "a", "b"));
-    }
-
-    private static void builtIn(
-        String name,
-        List<TermMode> modes,
-        List<String> fields
-    ) {
-        var shape = new Shape(name, fields);
-        var builtIn = new BuiltIn(shape, modes);
-        BUILT_INS.put(shape.relation(), builtIn);
-    }
 
     /**
      * Returns true if the relation names a built-in predicate, and false
@@ -166,10 +157,10 @@ public class RuleEngine {
         this.ruleset = ruleset;
         this.knownFacts = db;
         this.builtIns = Map.of(
-            MEMBER,         this::_member,
-            INDEXED_MEMBER, this::_indexedMember,
-            KEYED_MEMBER,   this::_keyedMember,
-            MAPS_TO,        this::_mapsTo
+            BuiltIn.MEMBER.relation(),         this::_member,
+            BuiltIn.INDEXED_MEMBER.relation(), this::_indexedMember,
+            BuiltIn.KEYED_MEMBER.relation(),   this::_keyedMember,
+            BuiltIn.MAPS_TO.relation(),        this::_mapsTo
         );
 
         // Define the predefined mapsTo/f,a,b mappers
@@ -607,13 +598,12 @@ public class RuleEngine {
 
     // member/item,collection
     private Set<Fact> _member(BindingContext bc, Atom atom) {
-        var names = BUILT_INS.get(MEMBER).shape().names();
         var coll = extractVar(bc, atom, 1);
         var facts = new HashSet<Fact>();
 
         if (coll instanceof Collection<?> c) {
             for (var item : c) {
-                facts.add(new Fact(MEMBER, names, List.of(item, c)));
+                facts.add(new Fact(BuiltIn.MEMBER.shape(), List.of(item, c)));
             }
         }
 
@@ -622,14 +612,13 @@ public class RuleEngine {
 
     // indexedMember/index,item,list
     private Set<Fact> _indexedMember(BindingContext bc, Atom atom) {
-        var names = BUILT_INS.get(INDEXED_MEMBER).shape().names();
         var coll = extractVar(bc, atom, 2);
         var facts = new HashSet<Fact>();
 
         if (coll instanceof List<?> list) {
             int index = 0;
             for (var item : list) {
-                facts.add(new Fact(INDEXED_MEMBER, names,
+                facts.add(new Fact(BuiltIn.INDEXED_MEMBER.shape(),
                     List.of((double)index, item, list)));
                 ++index;
             }
@@ -640,13 +629,12 @@ public class RuleEngine {
 
     // keyedMember/key,value,map
     private Set<Fact> _keyedMember(BindingContext bc, Atom atom) {
-        var names = BUILT_INS.get(KEYED_MEMBER).shape().names();
         var coll = extractVar(bc, atom, 2);
         var facts = new HashSet<Fact>();
 
         if (coll instanceof Map<?,?> map) {
             for (var e : map.entrySet()) {
-                facts.add(new Fact(KEYED_MEMBER, names,
+                facts.add(new Fact(BuiltIn.KEYED_MEMBER.shape(),
                     List.of(e.getKey(), e.getValue(), map)));
             }
         }
@@ -683,9 +671,7 @@ public class RuleEngine {
         }
         if (b == null) return facts;
 
-        facts.add(new Fact(MAPS_TO,
-            BUILT_INS.get(MAPS_TO).shape().names(),
-            List.of(f, a, b)));
+        facts.add(new Fact(BuiltIn.MAPS_TO.shape(), List.of(f, a, b)));
         return facts;
     }
 

--- a/lib/src/main/java/com/wjduquette/joe/nero/RuleEngine.java
+++ b/lib/src/main/java/com/wjduquette/joe/nero/RuleEngine.java
@@ -39,11 +39,8 @@ public class RuleEngine {
     }
 
     public enum BuiltIn {
-        MEMBER("member", List.of(INOUT, IN), List.of("item", "collection")),
-        INDEXED_MEMBER("indexedMember", List.of(INOUT, INOUT, IN),
-            List.of("index", "item", "list")),
-        KEYED_MEMBER("keyedMember", List.of(INOUT, INOUT, IN),
-            List.of("key", "value", "map")),
+        AT("at", List.of(IN, INOUT, INOUT), List.of("collection", "key", "item")),
+        HAS("has", List.of(IN, INOUT), List.of("collection", "item")),
         MAPS_TO("mapsTo", List.of(IN, IN, INOUT), List.of("f", "a", "b"));
 
         //---------------------------------------------------------------------
@@ -157,9 +154,8 @@ public class RuleEngine {
         this.ruleset = ruleset;
         this.knownFacts = db;
         this.builtIns = Map.of(
-            BuiltIn.MEMBER.relation(),         this::_member,
-            BuiltIn.INDEXED_MEMBER.relation(), this::_indexedMember,
-            BuiltIn.KEYED_MEMBER.relation(),   this::_keyedMember,
+            BuiltIn.AT.relation(),             this::_at,
+            BuiltIn.HAS.relation(),            this::_has,
             BuiltIn.MAPS_TO.relation(),        this::_mapsTo
         );
 
@@ -596,46 +592,36 @@ public class RuleEngine {
     //-------------------------------------------------------------------------
     // Built-In Predicates
 
-    // member/item,collection
-    private Set<Fact> _member(BindingContext bc, Atom atom) {
-        var coll = extractVar(bc, atom, 1);
-        var facts = new HashSet<Fact>();
-
-        if (coll instanceof Collection<?> c) {
-            for (var item : c) {
-                facts.add(new Fact(BuiltIn.MEMBER.shape(), List.of(item, c)));
-            }
-        }
-
-        return facts;
-    }
-
-    // indexedMember/index,item,list
-    private Set<Fact> _indexedMember(BindingContext bc, Atom atom) {
-        var coll = extractVar(bc, atom, 2);
+    // at/collection,key,item
+    private Set<Fact> _at(BindingContext bc, Atom atom) {
+        var coll = extractVar(bc, atom, 0);
         var facts = new HashSet<Fact>();
 
         if (coll instanceof List<?> list) {
             int index = 0;
             for (var item : list) {
-                facts.add(new Fact(BuiltIn.INDEXED_MEMBER.shape(),
-                    List.of((double)index, item, list)));
+                facts.add(new Fact(BuiltIn.AT.shape(),
+                    List.of(list, (double)index, item)));
                 ++index;
+            }
+        } else if (coll instanceof Map<?,?> map) {
+            for (var e : map.entrySet()) {
+                facts.add(new Fact(BuiltIn.AT.shape(),
+                    List.of(map, e.getKey(), e.getValue())));
             }
         }
 
         return facts;
     }
 
-    // keyedMember/key,value,map
-    private Set<Fact> _keyedMember(BindingContext bc, Atom atom) {
-        var coll = extractVar(bc, atom, 2);
+    // has/collection,item
+    private Set<Fact> _has(BindingContext bc, Atom atom) {
+        var coll = extractVar(bc, atom, 0);
         var facts = new HashSet<Fact>();
 
-        if (coll instanceof Map<?,?> map) {
-            for (var e : map.entrySet()) {
-                facts.add(new Fact(BuiltIn.KEYED_MEMBER.shape(),
-                    List.of(e.getKey(), e.getValue(), map)));
+        if (coll instanceof Collection<?> c) {
+            for (var i : c) {
+                facts.add(new Fact(BuiltIn.HAS.shape(), List.of(c, i)));
             }
         }
 

--- a/lib/src/main/java/com/wjduquette/joe/nero/RuleEngine.java
+++ b/lib/src/main/java/com/wjduquette/joe/nero/RuleEngine.java
@@ -38,9 +38,17 @@ public class RuleEngine {
         Set<Fact> compute(BindingContext bc, Atom builtIn);
     }
 
+    /**
+     * An enum of Nero's built-in predicates.
+     */
     public enum BuiltIn {
+        /** {@code at/collection, key, item} */
         AT("at", List.of(IN, INOUT, INOUT), List.of("collection", "key", "item")),
+
+        /** {@code has/collection, item} */
         HAS("has", List.of(IN, INOUT), List.of("collection", "item")),
+
+        /** {@code mapsTo/f, a, b} */
         MAPS_TO("mapsTo", List.of(IN, IN, INOUT), List.of("f", "a", "b"));
 
         //---------------------------------------------------------------------
@@ -54,8 +62,22 @@ public class RuleEngine {
             this.modes = modes;
         }
 
-        public String relation()      { return shape.relation(); }
-        public Shape shape()          { return shape; }
+        /**
+         * Gets the predicate's name.
+         * @return the name.
+         */
+        public String relation() { return shape.relation(); }
+
+        /**
+         * Gets the predicate's Shape.
+         * @return The shape.
+         */
+        public Shape shape() { return shape; }
+
+        /**
+         * Gets the modes of each of the predicate's terms.
+         * @return the modes.
+         */
         public List<TermMode> modes() { return modes; }
     }
 

--- a/lib/src/main/java/com/wjduquette/joe/parser/PatternParser.java
+++ b/lib/src/main/java/com/wjduquette/joe/parser/PatternParser.java
@@ -177,19 +177,16 @@ class PatternParser extends EmbeddedParser {
     private Pattern.MapPattern mapPattern(ASTPattern wp) {
         var map = new LinkedHashMap<Pattern,Pattern>();
 
-        if (scanner.match(COLON)) {
-            scanner.consume(RIGHT_BRACE, "expected '}' after empty map pattern.");
-            return new Pattern.MapPattern(map);
-        }
-
         do {
-            if (scanner.check(RIGHT_BRACE)) {
-                break;
-            }
             var key = constantPattern(wp);
+            if (key == null) {
+                throw errorSync(scanner.peek(), "expected map key after '{'.");
+            }
             scanner.consume(COLON, "expected ':' after map key.");
             var value = parsePattern(wp, true);
             map.put(key, value);
+
+            if (scanner.check(RIGHT_BRACE)) break;
         } while (scanner.match(COMMA));
 
         scanner.consume(RIGHT_BRACE, "expected '}' after map pattern items.");

--- a/lib/src/main/java/com/wjduquette/joe/patterns/Pattern.java
+++ b/lib/src/main/java/com/wjduquette/joe/patterns/Pattern.java
@@ -95,7 +95,12 @@ public sealed interface Pattern permits
      * {@link com.wjduquette.joe.JoeMap}.  Each key constant in the
      * {@code patterns} map must exist as a key in the target map, and
      * each key's value pattern in the {@code patterns} map must match
-     * the key's value in the target map.
+     * the key's value in the target map.  The pattern need not match
+     * all keys in the map.
+     *
+     * <p>Note: if the {@code patterns} map is empty, this pattern will
+     * match <b>any</b> map, not the <b>empty</b> map.  As this is often
+     * misleading, empty map syntax is disabled for map patterns.</p>
      * @param patterns The key constants and value patterns
      */
     record MapPattern(Map<Pattern,Pattern> patterns)

--- a/lib/src/test/java/com/wjduquette/joe/nero/RuleEngineTest.java
+++ b/lib/src/test/java/com/wjduquette/joe/nero/RuleEngineTest.java
@@ -783,6 +783,50 @@ public class RuleEngineTest extends Ted {
             """);
     }
 
+    @Test public void testBuiltIn_size_generate() {
+        test("testBuiltIn_size_generate");
+        var source = """
+            define transient Owner/id,list;
+            define Count/id,number;
+            Owner(#joe, [#hat, #boots, #truck]);
+            Owner(#bob, {#desk: #pc, #garage: #corvette});
+            Count(id, number) :- Owner(id, list), size(list, number);
+            """;
+        check(execute(source)).eq("""
+            define Count/id,number;
+            Count(#bob, 2);
+            Count(#joe, 3);
+            """);
+    }
+
+    @Test public void testBuiltIn_size_match() {
+        test("testBuiltIn_size_match");
+        var source = """
+            define transient Owner/id,list;
+            Owner(#joe, [#hat, #boots, #truck]);
+            Owner(#bob, {#desk: #pc, #garage: #corvette});
+            
+            define Has3/id;
+            Has3(id) :- Owner(id, list), size(list, 3);
+            """;
+        check(execute(source)).eq("""
+            define Has3/id;
+            Has3(#joe);
+            """);
+    }
+
+    @Test public void testBuiltIn_size_noCollection() {
+        test("testBuiltIn_size_generate");
+        var source = """
+            define transient Owner/id,list;
+            define Count/id,number;
+            Owner(#joe, #notACollection);
+            Count(id, number) :- Owner(id, list), size(list, number);
+            """;
+        check(execute(source)).eq("""
+            """);
+    }
+
     //-------------------------------------------------------------------------
     // Collection Literals
 

--- a/lib/src/test/java/com/wjduquette/joe/nero/RuleEngineTest.java
+++ b/lib/src/test/java/com/wjduquette/joe/nero/RuleEngineTest.java
@@ -602,55 +602,13 @@ public class RuleEngineTest extends Ted {
     //-------------------------------------------------------------------------
     // Built-in _predicates
 
-    @Test public void testBuiltIn_member_disaggregate() {
-        test("testBuiltIn_member_disaggregate");
-        var source = """
-            define transient Owner/id,list;
-            define Owns/id,item;
-            Owner(#joe, [#hat, #boots, #truck]);
-            Owns(id, item) :- Owner(id, list), member(item, list);
-            """;
-        check(execute(source)).eq("""
-            define Owns/id,item;
-            Owns(#joe, #boots);
-            Owns(#joe, #hat);
-            Owns(#joe, #truck);
-            """);
-    }
-
-    @Test public void testBuiltIn_member_match() {
-        test("testBuiltIn_member_match");
-        var source = """
-            define transient Owner/id,list;
-            define OwnsHat/id;
-            Owner(#joe, [#hat, #boots, #truck]);
-            OwnsHat(id) :- Owner(id, list), member(#hat, list);
-            """;
-        check(execute(source)).eq("""
-            define OwnsHat/id;
-            OwnsHat(#joe);
-            """);
-    }
-
-    @Test public void testBuiltIn_member_noCollection() {
-        test("testBuiltIn_member_noCollection");
-        var source = """
-            define transient Owner/id,list;
-            define Owns/id,item;
-            Owner(#joe, #notCollection);
-            Owns(id, item) :- Owner(id, list), member(item, list);
-            """;
-        check(execute(source)).eq("""
-            """);
-    }
-
-    @Test public void testBuiltIn_indexedMember_disaggregate() {
-        test("testBuiltIn_indexedMember_disaggregate");
+    @Test public void testBuiltIn_at_disaggregate_list() {
+        test("testBuiltIn_at_disaggregate_list");
         var source = """
             define transient Owner/id,list;
             define Owns/id,index,item;
             Owner(#joe, [#hat, #boots, #truck]);
-            Owns(id, i, item) :- Owner(id, list), indexedMember(i, item, list);
+            Owns(id, i, item) :- Owner(id, list), at(list, i, item);
             """;
         check(execute(source)).eq("""
             define Owns/id,index,item;
@@ -660,13 +618,13 @@ public class RuleEngineTest extends Ted {
             """);
     }
 
-    @Test public void testBuiltIn_indexedMember_match() {
-        test("testBuiltIn_indexedMember_match");
+    @Test public void testBuiltIn_at_match_list() {
+        test("testBuiltIn_at_match_list");
         var source = """
             define transient Owner/id,list;
             define OwnsHat/id,index;
             Owner(#joe, [#hat, #boots, #truck]);
-            OwnsHat(id, i) :- Owner(id, list), indexedMember(i, #hat, list);
+            OwnsHat(id, i) :- Owner(id, list), at(list, i, #hat);
             """;
         check(execute(source)).eq("""
             define OwnsHat/id,index;
@@ -674,25 +632,13 @@ public class RuleEngineTest extends Ted {
             """);
     }
 
-    @Test public void testBuiltIn_indexedMember_noCollection() {
-        test("testBuiltIn_indexedMember_noCollection");
-        var source = """
-            define transient Owner/id,list;
-            define Owns/id,index,item;
-            Owner(#joe, #notCollection);
-            Owns(id, i, item) :- Owner(id, list), indexedMember(i, item, list);
-            """;
-        check(execute(source)).eq("""
-            """);
-    }
-
-    @Test public void testBuiltIn_keyedMember_disaggregate() {
-        test("testBuiltIn_keyedMember_disaggregate");
+    @Test public void testBuiltIn_at_disaggregate_map() {
+        test("testBuiltIn_at_disaggregate_map");
         var source = """
             define transient Owner/id,map;
             define Wears/id,k,v;
             Owner(#joe, {#head: #hat, #feet: #boots});
-            Wears(id, k, v) :- Owner(id, map), keyedMember(k, v, map);
+            Wears(id, k, v) :- Owner(id, map), at(map, k, v);
             """;
         check(execute(source)).eq("""
             define Wears/id,k,v;
@@ -701,13 +647,13 @@ public class RuleEngineTest extends Ted {
             """);
     }
 
-    @Test public void testBuiltIn_keyedMember_match() {
-        test("testBuiltIn_keyedMember_match");
+    @Test public void testBuiltIn_at_match_map() {
+        test("testBuiltIn_at_match_map");
         var source = """
             define transient Owner/id,map;
             define WearsHat/id,k;
             Owner(#joe, {#head: #hat, #feet: #boots});
-            WearsHat(id, k) :- Owner(id, map), keyedMember(k, #hat, map);
+            WearsHat(id, k) :- Owner(id, map), at(map, k, #hat);
             """;
         check(execute(source)).eq("""
             define WearsHat/id,k;
@@ -715,13 +661,55 @@ public class RuleEngineTest extends Ted {
             """);
     }
 
-    @Test public void testBuiltIn_keyedMember_noCollection() {
-        test("testBuiltIn_keyedMember_noCollection");
+    @Test public void testBuiltIn_at_noCollection() {
+        test("testBuiltIn_at_noCollection");
         var source = """
-            define transient Owner/id,map;
-            define Wears/id,k,v;
+            define transient Owner/id,list;
+            define Owns/id,index,item;
             Owner(#joe, #notCollection);
-            Wears(id, k, v) :- Owner(id, map), keyedMember(k, v, map);
+            Owns(id, i, item) :- Owner(id, list), at(list, i, item);
+            """;
+        check(execute(source)).eq("""
+            """);
+    }
+
+    @Test public void testBuiltIn_has_disaggregate() {
+        test("testBuiltIn_has_disaggregate");
+        var source = """
+            define transient Owner/id,list;
+            define Owns/id,item;
+            Owner(#joe, [#hat, #boots, #truck]);
+            Owns(id, item) :- Owner(id, list), has(list, item);
+            """;
+        check(execute(source)).eq("""
+            define Owns/id,item;
+            Owns(#joe, #boots);
+            Owns(#joe, #hat);
+            Owns(#joe, #truck);
+            """);
+    }
+
+    @Test public void testBuiltIn_has_match() {
+        test("testBuiltIn_has_match");
+        var source = """
+            define transient Owner/id,list;
+            define OwnsHat/id;
+            Owner(#joe, [#hat, #boots, #truck]);
+            OwnsHat(id) :- Owner(id, list), has(list, #hat);
+            """;
+        check(execute(source)).eq("""
+            define OwnsHat/id;
+            OwnsHat(#joe);
+            """);
+    }
+
+    @Test public void testBuiltIn_has_noCollection() {
+        test("testBuiltIn_has_noCollection");
+        var source = """
+            define transient Owner/id,list;
+            define Owns/id,item;
+            Owner(#joe, #notCollection);
+            Owns(id, item) :- Owner(id, list), has(list, item);
             """;
         check(execute(source)).eq("""
             """);
@@ -787,7 +775,7 @@ public class RuleEngineTest extends Ted {
             Owner(#joe, [#hat, #boots, #truck]);
             
             define NotOwns/owner,item;
-            NotOwns(id, item) :- Owner(id, list), Item(item), not member(item, list);
+            NotOwns(id, item) :- Owner(id, list), Item(item), not has(list, item);
             """;
         check(execute(source)).eq("""
             define NotOwns/owner,item;
@@ -1135,7 +1123,7 @@ public class RuleEngineTest extends Ted {
             Event({#b,#e}, 6);
 
             define Min/id,t;
-            Min(id, min(t)) :- Event(ids, t), member(id, ids);
+            Min(id, min(t)) :- Event(ids, t), has(ids, id);
             """;
         check(execute(source)).eq("""
             define Min/id,t;

--- a/lib/src/test/java/com/wjduquette/joe/parser/NeroParserTest.java
+++ b/lib/src/test/java/com/wjduquette/joe/parser/NeroParserTest.java
@@ -30,10 +30,10 @@ public class NeroParserTest extends Ted {
         test("testParse_axiomBuiltIn");
 
         var source = """
-            member(#joe, 90);
+            has(#joe, 90);
             """;
         check(parseNero(source))
-            .eq("[line 1] error at 'member', found built-in predicate in axiom.");
+            .eq("[line 1] error at 'has', found built-in predicate in axiom.");
     }
 
     @Test public void testParse_axiomUndefined_tooBig() {
@@ -61,10 +61,10 @@ public class NeroParserTest extends Ted {
         test("testParse_headBuiltIn");
 
         var source = """
-            member(x, y) :- Foo(x, y);
+            has(x, y) :- Foo(x, y);
             """;
         check(parseNero(source))
-            .eq("[line 1] error at 'member', found built-in predicate in rule head.");
+            .eq("[line 1] error at 'has', found built-in predicate in rule head.");
     }
 
     @Test public void testParse_headUndefinedTooBig() {
@@ -115,10 +115,10 @@ public class NeroParserTest extends Ted {
         test("testTransientDeclaration_foundBuiltIn");
 
         var source = """
-            transient member;
+            transient has;
             """;
         check(parseNero(source))
-            .eq("[line 1] error at 'member', found built-in predicate in 'transient' declaration.");
+            .eq("[line 1] error at 'has', found built-in predicate in 'transient' declaration.");
     }
 
     @Test public void testTransientDeclaration_expectedSemicolon() {
@@ -148,10 +148,10 @@ public class NeroParserTest extends Ted {
         test("testDefineDeclaration_foundBuiltIn");
 
         var source = """
-            define member/2;
+            define has/2;
             """;
         check(parseNero(source))
-            .eq("[line 1] error at 'member', found built-in predicate in 'define' declaration.");
+            .eq("[line 1] error at 'has', found built-in predicate in 'define' declaration.");
     }
 
     @Test public void testDefineDeclaration_expectedSlash() {
@@ -441,60 +441,20 @@ public class NeroParserTest extends Ted {
         test("testCheckBuiltIn_shape");
         var source = """
             define Thing/x;
-            Thing(x) :- Foo(list), member(x, list, y);
+            Thing(x) :- Foo(list), has(x, list, y);
             """;
         check(parseNero(source))
-            .eq("[line 2] error at 'member', expected member/item,collection, got: 'member(x, list, y)'.");
+            .eq("[line 2] error at 'has', expected has/collection,item, got: 'has(x, list, y)'.");
     }
 
-    @Test public void testCheckBuiltIn_memberUnbound() {
-        test("testCheckBuiltIn_memberUnbound");
+    @Test public void testCheckBuiltIn_unbound() {
+        test("testCheckBuiltIn_unbound");
         var source = """
             define Thing/x;
-            Thing(x) :- Foo(list), member(x, items);
+            Thing(x) :- Foo(list), has(items, x);
             """;
         check(parseNero(source))
-            .eq("[line 2] error at 'member', expected bound variable or constant for term 'collection', got: 'items'.");
-    }
-
-    @Test public void testCheckBuiltIn_indexedMemberUnbound() {
-        test("testCheckBuiltIn_indexedMemberUnbound");
-        var source = """
-            define Thing/x;
-            Thing(x) :- Foo(list), indexedMember(i, x, items);
-            """;
-        check(parseNero(source))
-            .eq("[line 2] error at 'indexedMember', expected bound variable or constant for term 'list', got: 'items'.");
-    }
-
-    @Test public void testCheckBuiltIn_keyedMemberUnbound() {
-        test("testCheckBuiltIn_keyedMemberUnbound");
-        var source = """
-            define Thing/x;
-            Thing(x) :- Foo(map), keyedMember(k, v, items);
-            """;
-        check(parseNero(source))
-            .eq("[line 2] error at 'keyedMember', expected bound variable or constant for term 'map', got: 'items'.");
-    }
-
-    @Test public void testCheckBuiltIn_mapsTo_unknownF() {
-        test("testCheckBuiltIn_mapsTo_unknownF");
-        var source = """
-            define Thing/x;
-            Thing(n) :- Foo(s), mapsTo(y, s, n);
-            """;
-        check(parseNero(source))
-            .eq("[line 2] error at 'mapsTo', expected bound variable or constant for term 'f', got: 'y'.");
-    }
-
-    @Test public void testCheckBuiltIn_mapsTo_unknownA() {
-        test("testCheckBuiltIn_mapsTo_unknownA");
-        var source = """
-            define Thing/x;
-            Thing(n) :- Foo(s), mapsTo(#str2num, a, n);
-            """;
-        check(parseNero(source))
-            .eq("[line 2] error at 'mapsTo', expected bound variable or constant for term 'a', got: 'a'.");
+            .eq("[line 2] error at 'has', expected bound variable or constant for term 'collection', got: 'items'.");
     }
 
     //-------------------------------------------------------------------------

--- a/lib/src/test/java/com/wjduquette/joe/parser/PatternParserTest.java
+++ b/lib/src/test/java/com/wjduquette/joe/parser/PatternParserTest.java
@@ -114,15 +114,15 @@ public class PatternParserTest extends Ted {
     //-------------------------------------------------------------------------
     // mapPattern()
 
-    @Test public void testMapPattern_braceAfterEmpty() {
-        test("testMapPattern_braceAfterEmpty");
+    @Test public void testMapPattern_mapKeyAfterBrace() {
+        test("testMapPattern_mapKeyAfterBrace");
 
         var source = """
             var x;
             x ~ {:;
             """;
         check(parse(source))
-            .eq("[line 2] error at ';', expected '}' after empty map pattern.");
+            .eq("[line 2] error at ':', expected map key after '{'.");
     }
 
     @Test public void testMapPattern_expectedColon() {

--- a/tests/lang_pattern.joe
+++ b/tests/lang_pattern.joe
@@ -78,11 +78,6 @@ function testList_nestedPattern() {
 //-------------------------------------------------------------------------
 // Map Patterns
 
-function testMap_matchEmptyMap() {
-    // The {} pattern should be "{:}".
-    assertT({:} ~ {:});
-}
-
 // Value isn't a map
 function testMap_noMap() {
     assertF(5 ~ {#abc: a});


### PR DESCRIPTION
This pull request includes several changes related to collection patterns in Nero rule sets.

- `{:}` is no longer a valid map pattern; it's ambiguous and confusing.
- `{}` is no longer treated as a valid pattern.
- Replaced the `member` Nero predicate with the shorter `has`
- Replaced the `indexedMember` and `keyedMember` predicate with the shorter
  `at` predicate.
- Added the `size` predicate.
- Updated tests and docs.