### PR TITLE
Typed comparisons

### DIFF
--- a/jug/src/nero/builtin_predicates.md
+++ b/jug/src/nero/builtin_predicates.md
@@ -17,6 +17,10 @@ Nero provides the following built-in predicates.
 
 - [`has/collection, item`](#hascollection-item) (`IN`, `INOUT`)
 - [`at/collection, key, item`](#atcollection-key-item) (`IN`, `INOUT`, `INOUT`)
+- [`ge/type, a, b`](#getype-a-b) (`IN`, `IN`, `IN`)
+- [`gt/type, a, b`](#gttype-a-b) (`IN`, `IN`, `IN`)
+- [`le/type, a, b`](#letype-a-b) (`IN`, `IN`, `IN`)
+- [`lt/type, a, b`](#lttype-a-b) (`IN`, `IN`, `IN`)
 - [`mapsTo/f, a, b`](#mapstof-a-b) (`IN`, `IN`, `INOUT`)
 - [`size/collection, number`](#sizecollection-number) (`IN`, `INOUT`)
 
@@ -132,6 +136,111 @@ yields these facts:
 **Note:** the `map(k, v)`
 [aggregation function](aggregation_functions.md) can reaggregate the items
 back into the original map.
+
+## `ge/type, a, b`
+
+The `ge/type, a, b` tests whether value *a* (`IN`) is greater than 
+or equal to
+value *b* (`IN`), provided that they are both of type *type* (`IN`).
+If *a* and *b* are not both of the given *type*, the match fails.
+
+The *type* is an aggregation type keyword; see
+[Aggregation Types](aggregation_functions.md#aggregation_types).
+`#string` and `#number` are provided; clients can define additional
+types.
+
+For example, this program
+
+```nero
+Pair(1, 1);
+Pair(1, 2);
+Pair(2, 1);
+
+Result(a, b) :- Pair(a, b), ge(#number, a, b);
+```
+
+yields these facts:
+
+- `Result(1, 1)`
+- `Result(2, 1)`
+ 
+## `gt/type, a, b`
+
+The `gt/type, a, b` tests whether value *a* (`IN`) is greater than
+value *b* (`IN`), provided that they are both of type *type* (`IN`).
+If *a* and *b* are not both of the given *type*, the match fails.
+
+The *type* is an aggregation type keyword; see
+[Aggregation Types](aggregation_functions.md#aggregation_types).
+`#string` and `#number` are provided; clients can define additional
+types.
+
+For example, this program
+
+```nero
+Pair(1, 1);
+Pair(1, 2);
+Pair(2, 1);
+
+Result(a, b) :- Pair(a, b), gt(#number, a, b);
+```
+
+yields these facts:
+
+- `Result(2, 1)`
+ 
+## `le/type, a, b`
+
+The `le/type, a, b` tests whether value *a* (`IN`) is less than
+or equal to
+value *b* (`IN`), provided that they are both of type *type* (`IN`).
+If *a* and *b* are not both of the given *type*, the match fails.
+
+The *type* is an aggregation type keyword; see
+[Aggregation Types](aggregation_functions.md#aggregation_types).
+`#string` and `#number` are provided; clients can define additional
+types.
+
+For example, this program
+
+```nero
+Pair(1, 1);
+Pair(1, 2);
+Pair(2, 1);
+
+Result(a, b) :- Pair(a, b), le(#number, a, b);
+```
+
+yields these facts:
+
+- `Result(1, 1)`
+- `Result(1, 2)`
+
+## `lt/type, a, b`
+
+The `lt/type, a, b` tests whether value *a* (`IN`) is less than
+value *b* (`IN`), provided that they are both of type *type* (`IN`).
+If *a* and *b* are not both of the given *type*, the match fails.
+
+The *type* is an aggregation type keyword; see
+[Aggregation Types](aggregation_functions.md#aggregation_types).
+`#string` and `#number` are provided; clients can define additional
+types.
+
+For example, this program
+
+```nero
+Pair(1, 1);
+Pair(1, 2);
+Pair(2, 1);
+
+Result(a, b) :- Pair(a, b), lt(#number, a, b);
+```
+
+yields these facts:
+
+- `Result(1, 2)`
+
 
 ## `mapsTo/f, a, b`
 

--- a/lib/src/main/java/com/wjduquette/joe/nero/RuleEngine.java
+++ b/lib/src/main/java/com/wjduquette/joe/nero/RuleEngine.java
@@ -45,8 +45,20 @@ public class RuleEngine {
         /** {@code at/collection, key, item} */
         AT("at", List.of(IN, INOUT, INOUT), List.of("collection", "key", "item")),
 
+        /** {@code ge/type, a, b} */
+        GE("ge", List.of(IN, IN, IN), List.of("type", "a", "b")),
+
+        /** {@code gt/type, a, b} */
+        GT("gt", List.of(IN, IN, IN), List.of("type", "a", "b")),
+
         /** {@code has/collection, item} */
         HAS("has", List.of(IN, INOUT), List.of("collection", "item")),
+
+        /** {@code le/type, a, b} */
+        LE("le", List.of(IN, IN, IN), List.of("type", "a", "b")),
+
+        /** {@code lt/type, a, b} */
+        LT("lt", List.of(IN, IN, IN), List.of("type", "a", "b")),
 
         /** {@code mapsTo/f, a, b} */
         MAPS_TO("mapsTo", List.of(IN, IN, INOUT), List.of("f", "a", "b")),
@@ -190,7 +202,11 @@ public class RuleEngine {
         this.knownFacts = db;
         this.builtIns = Map.of(
             BuiltIn.AT.relation(),          this::_at,
+            BuiltIn.GE.relation(),          this::_ge,
+            BuiltIn.GT.relation(),          this::_gt,
             BuiltIn.HAS.relation(),         this::_has,
+            BuiltIn.LE.relation(),          this::_le,
+            BuiltIn.LT.relation(),          this::_lt,
             BuiltIn.MAPS_TO.relation(),     this::_mapsTo,
             BuiltIn.SIZE.relation(),        this::_size
         );
@@ -663,6 +679,60 @@ public class RuleEngine {
         return facts;
     }
 
+    // ge/type,a,b
+    private Set<Fact> _ge(BindingContext bc, Atom theAtom) {
+        var atom = (ListAtom)theAtom;
+        var type = term2value(atom.terms().get(0), bc);
+        var a = term2value(atom.terms().get(1), bc);
+        var b = term2value(atom.terms().get(2), bc);
+        var facts = new HashSet<Fact>();
+
+        Comparer comparer = null;
+        if (type instanceof Keyword kw) {
+            comparer = comparers.get(kw);
+        }
+
+        if (comparer == null) {
+            throw joe.expected(
+                "type keyword of registered comparer in 'ge(type, a, b)'",
+                type);
+        }
+
+        var result = compare(comparer, a, b);
+        if (result != null && result >= 0) {
+            facts.add(new Fact(BuiltIn.GE.shape(), List.of(type, a, b)));
+        }
+
+        return facts;
+    }
+
+    // gt/type,a,b
+    private Set<Fact> _gt(BindingContext bc, Atom theAtom) {
+        var atom = (ListAtom)theAtom;
+        var type = term2value(atom.terms().get(0), bc);
+        var a = term2value(atom.terms().get(1), bc);
+        var b = term2value(atom.terms().get(2), bc);
+        var facts = new HashSet<Fact>();
+
+        Comparer comparer = null;
+        if (type instanceof Keyword kw) {
+            comparer = comparers.get(kw);
+        }
+
+        if (comparer == null) {
+            throw joe.expected(
+                "type keyword of registered comparer in 'gt(type, a, b)'",
+                type);
+        }
+
+        var result = compare(comparer, a, b);
+        if (result != null && result > 0) {
+            facts.add(new Fact(BuiltIn.GT.shape(), List.of(type, a, b)));
+        }
+
+        return facts;
+    }
+
     // has/collection,item
     private Set<Fact> _has(BindingContext bc, Atom atom) {
         var coll = extractVar(bc, atom, 0);
@@ -675,6 +745,60 @@ public class RuleEngine {
                 list.add(i);
                 facts.add(new Fact(BuiltIn.HAS.shape(), list));
             }
+        }
+
+        return facts;
+    }
+
+    // le/type,a,b
+    private Set<Fact> _le(BindingContext bc, Atom theAtom) {
+        var atom = (ListAtom)theAtom;
+        var type = term2value(atom.terms().get(0), bc);
+        var a = term2value(atom.terms().get(1), bc);
+        var b = term2value(atom.terms().get(2), bc);
+        var facts = new HashSet<Fact>();
+
+        Comparer comparer = null;
+        if (type instanceof Keyword kw) {
+            comparer = comparers.get(kw);
+        }
+
+        if (comparer == null) {
+            throw joe.expected(
+                "type keyword of registered comparer in 'le(type, a, b)'",
+                type);
+        }
+
+        var result = compare(comparer, a, b);
+        if (result != null && result <= 0) {
+            facts.add(new Fact(BuiltIn.LE.shape(), List.of(type, a, b)));
+        }
+
+        return facts;
+    }
+
+    // lt/type,a,b
+    private Set<Fact> _lt(BindingContext bc, Atom theAtom) {
+        var atom = (ListAtom)theAtom;
+        var type = term2value(atom.terms().get(0), bc);
+        var a = term2value(atom.terms().get(1), bc);
+        var b = term2value(atom.terms().get(2), bc);
+        var facts = new HashSet<Fact>();
+
+        Comparer comparer = null;
+        if (type instanceof Keyword kw) {
+            comparer = comparers.get(kw);
+        }
+
+        if (comparer == null) {
+            throw joe.expected(
+                "type keyword of registered comparer in 'lt(type, a, b)'",
+                type);
+        }
+
+        var result = compare(comparer, a, b);
+        if (result != null && result < 0) {
+            facts.add(new Fact(BuiltIn.LT.shape(), List.of(type, a, b)));
         }
 
         return facts;

--- a/lib/src/test/java/com/wjduquette/joe/nero/RuleEngineTest.java
+++ b/lib/src/test/java/com/wjduquette/joe/nero/RuleEngineTest.java
@@ -673,6 +673,72 @@ public class RuleEngineTest extends Ted {
             """);
     }
 
+    @Test public void testBuiltIn_ge() {
+        test("testBuiltIn_ge");
+        var source = """
+            transient Foo;
+            Foo(1, 1);
+            Foo(1, 2);
+            Foo(2, 1);
+            Foo(2, "a");
+            Bar(a, b) :- Foo(a, b), ge(#number, a, b);
+            """;
+        check(execute(source)).eq("""
+            define Bar/a,b;
+            Bar(1, 1);
+            Bar(2, 1);
+            """);
+    }
+
+    @Test public void testBuiltIn_gt() {
+        test("testBuiltIn_gt");
+        var source = """
+            transient Foo;
+            Foo(1, 1);
+            Foo(1, 2);
+            Foo(2, 1);
+            Foo(2, "a");
+            Bar(a, b) :- Foo(a, b), gt(#number, a, b);
+            """;
+        check(execute(source)).eq("""
+            define Bar/a,b;
+            Bar(2, 1);
+            """);
+    }
+
+    @Test public void testBuiltIn_le() {
+        test("testBuiltIn_le");
+        var source = """
+            transient Foo;
+            Foo(1, 1);
+            Foo(1, 2);
+            Foo(2, 1);
+            Foo(2, "a");
+            Bar(a, b) :- Foo(a, b), le(#number, a, b);
+            """;
+        check(execute(source)).eq("""
+            define Bar/a,b;
+            Bar(1, 1);
+            Bar(1, 2);
+            """);
+    }
+
+    @Test public void testBuiltIn_lt() {
+        test("testBuiltIn_lt");
+        var source = """
+            transient Foo;
+            Foo(1, 1);
+            Foo(1, 2);
+            Foo(2, 1);
+            Foo(2, "a");
+            Bar(a, b) :- Foo(a, b), lt(#number, a, b);
+            """;
+        check(execute(source)).eq("""
+            define Bar/a,b;
+            Bar(1, 2);
+            """);
+    }
+
     @Test public void testBuiltIn_has_disaggregate() {
         test("testBuiltIn_has_disaggregate");
         var source = """


### PR DESCRIPTION
This pull requests adds built-in predicates for typed comparisons:
both values are of a given type, and have the given relationship, e.g.,
`gt`, "greater than`.  This new predicates use the same aggregation
types as the `mint()` and `maxt()` aggregation functions.